### PR TITLE
Propagate api call errors to the llm

### DIFF
--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -74,11 +74,7 @@ def build_failure_structured_content(
 
 
 def derive_legacy_content(structured_content: dict) -> str:
-    s = structured_content["message"]
-    if "error" in structured_content:
-        s += f": {structured_content['error']}"
-        if "response" in structured_content:
-            s += f"\n{str(structured_content['response'])}"
-    else:
-        s += f": {str(structured_content['response'])}"
-    return s
+    parts = [
+        f"# {key.capitalize()}\n{value}\n" for key, value in structured_content.items()
+    ]
+    return "\n".join(parts)

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from fastmcp.tools.tool import ToolResult
@@ -69,7 +70,10 @@ def build_failure_structured_content(
         "error": str(exception),
     }
     if isinstance(exception, HTTPError):
-        structured_content["response"] = exception.response.text
+        try:
+            structured_content["response"] = json.loads(exception.response.text)
+        except json.JSONDecodeError:
+            structured_content["response"] = exception.response.text
     return structured_content
 
 

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -2,9 +2,9 @@ import json
 from typing import Any
 
 from fastmcp.tools.tool import ToolResult
-from mcp.types import TextContent
 from requests.exceptions import HTTPError
 
+from ..utils.content_utils import build_tool_result
 from ..utils.utils import assert_resource
 
 
@@ -36,22 +36,14 @@ def register_call_foreman_api(mcp, foreman_api, get_context):
 
 def format_success_response(resource: str, action: str, response: str) -> ToolResult:
     structured_content = build_success_structured_content(resource, action, response)
-    content = derive_legacy_content(structured_content)
-    return ToolResult(
-        content=[TextContent(type="text", text=content)],
-        structured_content=structured_content,
-    )
+    return build_tool_result(structured_content)
 
 
 def format_failure_response(
     resource: str, action: str, exception: Exception
 ) -> ToolResult:
     structured_content = build_failure_structured_content(resource, action, exception)
-    content = derive_legacy_content(structured_content)
-    return ToolResult(
-        content=[TextContent(type="text", text=content)],
-        structured_content=structured_content,
-    )
+    return build_tool_result(structured_content)
 
 
 def build_success_structured_content(resource: str, action: str, response: Any) -> dict:
@@ -77,14 +69,3 @@ def build_failure_structured_content(
             except json.JSONDecodeError:
                 structured_content["response"] = text
     return structured_content
-
-
-def derive_legacy_content(structured_content: dict) -> str:
-    parts = [to_markdown_like(key, value) for key, value in structured_content.items()]
-    return "\n".join(parts)
-
-
-def to_markdown_like(key: str, value: Any) -> str:
-    if isinstance(value, dict | list):
-        value = f"```json\n{json.dumps(value, indent=2)}\n```"
-    return f"# {key.capitalize()}\n{value}\n"

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -70,10 +70,12 @@ def build_failure_structured_content(
         "error": str(exception),
     }
     if isinstance(exception, HTTPError):
-        try:
-            structured_content["response"] = json.loads(exception.response.text)
-        except json.JSONDecodeError:
-            structured_content["response"] = exception.response.text
+        text = getattr(exception.response, "text", None)
+        if text:
+            try:
+                structured_content["response"] = json.loads(text)
+            except json.JSONDecodeError:
+                structured_content["response"] = text
     return structured_content
 
 

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -78,7 +78,11 @@ def build_failure_structured_content(
 
 
 def derive_legacy_content(structured_content: dict) -> str:
-    parts = [
-        f"# {key.capitalize()}\n{value}\n" for key, value in structured_content.items()
-    ]
+    parts = [to_markdown_like(key, value) for key, value in structured_content.items()]
     return "\n".join(parts)
+
+
+def to_markdown_like(key: str, value: Any) -> str:
+    if isinstance(value, dict | list):
+        value = f"```json\n{json.dumps(value, indent=2)}\n```"
+    return f"# {key.capitalize()}\n{value}\n"

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
+from requests.exceptions import HTTPError
 
 from ..utils.utils import assert_resource
 
@@ -25,16 +28,57 @@ def register_call_foreman_api(mcp, foreman_api, get_context):
                 get_context,
             )
             response = foreman_api.call(resource, action, params)
-            message = (
-                f"Action '{action}' on resource '{resource}' executed successfully."
-            )
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {response}")],
-                structured_content={"message": message, "response": response},
-            )
+            return format_success_response(resource, action, response)
         except Exception as e:
-            message = f"Failed to execute action '{action}' on resource '{resource}'"
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {str(e)}")],
-                structured_content={"message": message, "error": str(e)},
-            )
+            return format_failure_response(resource, action, e)
+
+
+def format_success_response(resource: str, action: str, response: str) -> ToolResult:
+    structured_content = build_success_structured_content(resource, action, response)
+    content = derive_legacy_content(structured_content)
+    return ToolResult(
+        content=[TextContent(type="text", text=content)],
+        structured_content=structured_content,
+    )
+
+
+def format_failure_response(
+    resource: str, action: str, exception: Exception
+) -> ToolResult:
+    structured_content = build_failure_structured_content(resource, action, exception)
+    content = derive_legacy_content(structured_content)
+    return ToolResult(
+        content=[TextContent(type="text", text=content)],
+        structured_content=structured_content,
+    )
+
+
+def build_success_structured_content(resource: str, action: str, response: Any) -> dict:
+    return {
+        "message": f"Action '{action}' on resource '{resource}' executed successfully.",
+        "response": response,
+    }
+
+
+def build_failure_structured_content(
+    resource: str, action: str, exception: Exception
+) -> dict:
+    message = f"Failed to execute action '{action}' on resource '{resource}'"
+    structured_content = {
+        "message": message,
+        "error": str(exception),
+    }
+    if isinstance(exception, HTTPError):
+        structured_content["response"] = exception.response.text
+    return structured_content
+
+
+def derive_legacy_content(structured_content: dict) -> str:
+    s = structured_content["message"]
+    if "error" in structured_content:
+        s += f": {structured_content['error']}"
+        if "response" in structured_content:
+            s += f"\n{str(structured_content['response'])}"
+    else:
+        s += f": {str(structured_content['response'])}"
+    return s

--- a/src/foreman_mcp_server/tools/fetch_foreman_dsl_docs.py
+++ b/src/foreman_mcp_server/tools/fetch_foreman_dsl_docs.py
@@ -1,6 +1,6 @@
 from fastmcp.tools.tool import ToolResult
-from mcp.types import TextContent
 
+from ..utils.content_utils import build_tool_result
 from ..utils.dsl_docs_utils import save_dsl_docs_as_markdown
 from ..utils.utils import assert_resource
 
@@ -34,17 +34,18 @@ def register_fetch_foreman_dsl_docs(mcp, foreman_api, get_context):
                 foreman_api.apidoc_cache_dir, f"{section}.en.md", response
             )
             message = f"DSL documentation for section '{section}' fetched successfully and saved to cache."
-            return ToolResult(
-                content=[TextContent(type="text", text=message)],
-                structured_content={
+            return build_tool_result(
+                {
                     "message": message,
                     "file": f"{section}.en.md",
                     "state": "present",
-                },
+                }
             )
         except Exception as e:
             message = f"Failed to fetch DSL documentation for section '{section}'"
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {str(e)}")],
-                structured_content={"message": message, "error": str(e)},
+            return build_tool_result(
+                {
+                    "message": message,
+                    "error": str(e),
+                }
             )

--- a/src/foreman_mcp_server/tools/get_foreman_api_resource_docs.py
+++ b/src/foreman_mcp_server/tools/get_foreman_api_resource_docs.py
@@ -1,6 +1,6 @@
 from fastmcp.tools.tool import ToolResult
-from mcp.types import TextContent
 
+from ..utils.content_utils import build_tool_result
 from ..utils.utils import assert_resource
 
 
@@ -29,17 +29,18 @@ def register_get_foreman_api_resource_docs(mcp, foreman_api, get_context):
             message = (
                 f"API documentation for resource '{resource}' fetched successfully"
             )
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {docs}")],
-                structured_content={
+            return build_tool_result(
+                {
                     "message": message,
                     "resource": resource,
                     "documentation": docs,
-                },
+                }
             )
         except Exception as e:
             message = f"Failed to read API documentation for resource '{resource}'"
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {str(e)}")],
-                structured_content={"message": message, "error": str(e)},
+            return build_tool_result(
+                {
+                    "message": message,
+                    "error": str(e),
+                }
             )

--- a/src/foreman_mcp_server/tools/get_foreman_dsl_docs.py
+++ b/src/foreman_mcp_server/tools/get_foreman_dsl_docs.py
@@ -1,6 +1,6 @@
 from fastmcp.tools.tool import ToolResult
-from mcp.types import TextContent
 
+from ..utils.content_utils import build_tool_result
 from ..utils.dsl_docs_utils import read_dsl_docs_from_markdown
 from ..utils.utils import assert_resource
 
@@ -29,27 +29,27 @@ def register_get_foreman_dsl_docs(mcp, foreman_api, get_context):
                 foreman_api.apidoc_cache_dir, f"{section}.en.md"
             )
             message = f"DSL documentation for section '{section}' read successfully"
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {docs}")],
-                structured_content={
+            return build_tool_result(
+                {
                     "message": message,
                     "section": section,
                     "documentation": docs,
-                },
+                }
             )
         except FileNotFoundError:
             message = f"The cache file for section '{section}' is not found. Please fetch the DSL documentation first."
-            return ToolResult(
-                content=[TextContent(type="text", text=message)],
-                structured_content={
+            return build_tool_result(
+                {
                     "message": message,
                     "file": f"{section}.en.md",
                     "state": "absent",
-                },
+                }
             )
         except Exception as e:
             message = f"Failed to read DSL documentation for section '{section}'"
-            return ToolResult(
-                content=[TextContent(type="text", text=f"{message}: {str(e)}")],
-                structured_content={"message": message, "error": str(e)},
+            return build_tool_result(
+                {
+                    "message": message,
+                    "error": str(e),
+                }
             )

--- a/src/foreman_mcp_server/utils/content_utils.py
+++ b/src/foreman_mcp_server/utils/content_utils.py
@@ -1,0 +1,27 @@
+import json
+from typing import Any
+
+from fastmcp.tools.tool import ToolResult
+from mcp.types import TextContent
+
+
+def to_markdown_like(key: str, value: Any) -> str:
+    """Convert a key-value pair to markdown-like format."""
+    if isinstance(value, dict | list):
+        value = f"```json\n{json.dumps(value, indent=2)}\n```"
+    return f"# {key.capitalize()}\n{value}\n"
+
+
+def derive_legacy_content(structured_content: dict) -> str:
+    """Convert structured content dictionary to markdown-like string."""
+    parts = [to_markdown_like(key, value) for key, value in structured_content.items()]
+    return "\n".join(parts)
+
+
+def build_tool_result(structured_content: dict) -> ToolResult:
+    """Build a ToolResult with both structured content and derived text content."""
+    content = derive_legacy_content(structured_content)
+    return ToolResult(
+        content=[TextContent(type="text", text=content)],
+        structured_content=structured_content,
+    )

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -80,3 +80,29 @@ test error
 <html>test error</html>
 """
         )
+
+    def test_build_failure_with_http_error_and_json_response(self):
+        error = HTTPError("test error", response=Mock(text='{"error": "test error"}'))
+        expected = {
+            "message": "Failed to execute action 'test_action' on resource 'test_resource'",
+            "error": "test error",
+            "response": {"error": "test error"},
+        }
+        structured = build_failure_structured_content(
+            "test_resource", "test_action", error
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == """# Message
+Failed to execute action 'test_action' on resource 'test_resource'
+
+# Error
+test error
+
+# Response
+{'error': 'test error'}
+"""
+        )

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock
+
+from requests.exceptions import HTTPError
+
+from foreman_mcp_server.tools.call_foreman_api import (
+    build_failure_structured_content,
+    build_success_structured_content,
+    derive_legacy_content,
+)
+
+
+class TestCallForemanApi:
+    def test_build_success_content(self):
+        response = "test response"
+        expected = {
+            "message": "Action 'test_action' on resource 'test_resource' executed successfully.",
+            "response": response,
+        }
+        structured = build_success_structured_content(
+            "test_resource", "test_action", response
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == "Action 'test_action' on resource 'test_resource' executed successfully.: test response"
+        )
+
+    def test_build_failure_content(self):
+        error = Exception("test error")
+        expected = {
+            "message": "Failed to execute action 'test_action' on resource 'test_resource'",
+            "error": "test error",
+        }
+
+        structured = build_failure_structured_content(
+            "test_resource", "test_action", error
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == "Failed to execute action 'test_action' on resource 'test_resource': test error"
+        )
+
+    def test_build_failure_with_http_error(self):
+        error = HTTPError("test error", response=Mock(text="<html>test error</html>"))
+        expected = {
+            "message": "Failed to execute action 'test_action' on resource 'test_resource'",
+            "error": "test error",
+            "response": "<html>test error</html>",
+        }
+        structured = build_failure_structured_content(
+            "test_resource", "test_action", error
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == "Failed to execute action 'test_action' on resource 'test_resource': test error\n<html>test error</html>"
+        )

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -5,8 +5,8 @@ from requests.exceptions import HTTPError
 from foreman_mcp_server.tools.call_foreman_api import (
     build_failure_structured_content,
     build_success_structured_content,
-    derive_legacy_content,
 )
+from foreman_mcp_server.utils.content_utils import derive_legacy_content
 
 
 class TestCallForemanApi:

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -24,7 +24,12 @@ class TestCallForemanApi:
         content = derive_legacy_content(structured)
         assert (
             content
-            == "Action 'test_action' on resource 'test_resource' executed successfully.: test response"
+            == """# Message
+Action 'test_action' on resource 'test_resource' executed successfully.
+
+# Response
+test response
+"""
         )
 
     def test_build_failure_content(self):
@@ -42,7 +47,12 @@ class TestCallForemanApi:
         content = derive_legacy_content(structured)
         assert (
             content
-            == "Failed to execute action 'test_action' on resource 'test_resource': test error"
+            == """# Message
+Failed to execute action 'test_action' on resource 'test_resource'
+
+# Error
+test error
+"""
         )
 
     def test_build_failure_with_http_error(self):
@@ -60,5 +70,13 @@ class TestCallForemanApi:
         content = derive_legacy_content(structured)
         assert (
             content
-            == "Failed to execute action 'test_action' on resource 'test_resource': test error\n<html>test error</html>"
+            == """# Message
+Failed to execute action 'test_action' on resource 'test_resource'
+
+# Error
+test error
+
+# Response
+<html>test error</html>
+"""
         )

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -103,6 +103,10 @@ Failed to execute action 'test_action' on resource 'test_resource'
 test error
 
 # Response
-{'error': 'test error'}
+```json
+{
+  "error": "test error"
+}
+```
 """
         )


### PR DESCRIPTION
Prompt
```
Search for hosts belonging to subnet called "default"
```

# 1) call_foreman_api
Input
```json
{
  "action": "index",
  "resource": "hosts",
  "params": {
    "search": "subnet_id=2"
  }
}
```

Output
````markdown
# Message
Failed to execute action 'index' on resource 'hosts'

# Error
500 Server Error: Internal Server Error for url: https://something.somewhere.com/api/hosts?search=subnet_id%3D2

# Response
```json
{
  "displayMessage": "Field 'subnet_id' not recognized for searching!",
  "errors": [
    "Field 'subnet_id' not recognized for searching!"
  ]
}
```
````

# 2) call_foreman_api
Input
```json
{
  "action": "index",
  "resource": "hosts",
  "params": {
    "search": "subnet = \"default\""
  }
}
```

Output
````markdown
# Message
Action 'index' on resource 'hosts' executed successfully.

# Response
```json
{
  "total": 201,
  "subtotal": 0,
  "page": 1,
  "per_page": 20,
  "search": "subnet=\"default\"",
  "sort": {
    "by": null,
    "order": null
  },
  "results": []
}
```
````