### PR TITLE
Make GET-only API requests

### DIFF
--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -1,4 +1,4 @@
-from .call_foreman_api import register_call_foreman_api
+from .call_foreman_api import register_foreman_api_methods
 from .fetch_foreman_dsl_docs import register_fetch_foreman_dsl_docs
 from .get_foreman_api_resource_docs import register_get_foreman_api_resource_docs
 from .get_foreman_dsl_docs import register_get_foreman_dsl_docs
@@ -10,7 +10,7 @@ from .get_foreman_dsl_docs import register_get_foreman_dsl_docs
 def register_tools(mcp, foreman_api, get_context):
     """Register all tools with the MCP server."""
 
-    register_call_foreman_api(mcp, foreman_api, get_context)
+    register_foreman_api_methods(mcp, foreman_api, get_context)
     register_fetch_foreman_dsl_docs(mcp, foreman_api, get_context)
     # TODO: Remove when Claude Desktop supports Resource with parameters
     register_get_foreman_api_resource_docs(mcp, foreman_api, get_context)

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -5,28 +5,35 @@ from fastmcp.tools.tool import ToolResult
 from requests.exceptions import HTTPError
 
 from ..utils.content_utils import build_tool_result
-from ..utils.utils import assert_resource, mcp_info_headers
+from ..utils.utils import assert_http_method, assert_resource, mcp_info_headers
 
 
 # TODO: Probably split it into multiple tools (read-only, destructive, etc)
-def register_call_foreman_api(mcp, foreman_api, get_context):
+def register_foreman_api_methods(mcp, foreman_api, get_context):
     @mcp.tool(
-        description="Calls an action on a Foreman API resource.",
-        tags=("foreman", "api", "action", "resource", "remote"),
+        description="Calls GET action on Foreman API.",
+        tags=("foreman", "api", "get", "resource", "remote"),
         annotations={
-            "title": "Call Foreman API Action",
-            "readOnlyHint": False,
-            "destructiveHint": True,
+            "title": "Call Foreman API GET Action",
+            "readOnlyHint": True,
+            "destructiveHint": False,
             "idempotentHint": False,
             "openWorldHint": False,
         },
     )
-    async def call_foreman_api(resource: str, action: str, params: dict) -> ToolResult:
+    async def call_foreman_api_get(
+        resource: str, action: str, params: dict
+    ) -> ToolResult:
         try:
             await assert_resource(
                 resource,
                 {"name": "Resource", "list_name": "resources", "type": "api"},
                 get_context,
+            )
+            assert_http_method(
+                foreman_api,
+                {"name": action, "resource": resource, "params": params},
+                "get",
             )
             response = foreman_api.call(
                 resource, action, params, mcp_info_headers(get_context)

--- a/src/foreman_mcp_server/utils/utils.py
+++ b/src/foreman_mcp_server/utils/utils.py
@@ -1,5 +1,6 @@
 # TODO: Needs refactoring, better error handling or entire removal.
 
+from apypie.resource import Resource
 from fastmcp.exceptions import ToolError
 
 
@@ -16,6 +17,20 @@ async def assert_resource(
     if to_check not in resources:
         message = f"{resource_info['name']} '{to_check}' is not available in the list"
         raise ToolError(f"{message}: {', '.join(resources)}")
+    else:
+        return True
+
+
+def assert_http_method(foreman_api, action_info: dict, http_method: str) -> bool | None:
+    """Checks if the action uses provided HTTP method on the resource."""
+    resource = Resource(foreman_api, action_info["resource"])
+    action = resource.action(action_info["name"])
+    route = action.find_route(action_info["params"])
+    if route.method != http_method.lower():
+        message = f"Action '{action_info['name']}' on resource '{action_info['resource']}' is not allowed"
+        raise ToolError(
+            f"{message}: {route.method.upper()} method is not allowed, expected {http_method.upper()}."
+        )
     else:
         return True
 


### PR DESCRIPTION
@adamruzicka I guess that should do it. I might over-complicated things... The current way is for the idea of separate tools for each type of the requests. We also could provide the same tool, but mention in the description and error message that it's currently limited to GET actions. WDYT?