### PR TITLE
Add naive auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ uv run foreman-mcp-server \
   --host localhost \
   --port 8080 \
   --transport streamable-http
+  --no-verify-ssl
 ```
 
 Default values if not provided:
@@ -26,6 +27,7 @@ Default values if not provided:
   --host '127.0.0.1'
   --port 8080
   --transport streamable-http
+  --verify-ssl
 ```
 
 ## Start the server via podman

--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ uv run foreman-mcp-server \
   --log-level debug \
   --host localhost \
   --port 8080 \
-  --transport streamable-http
+  --transport stdio
   --no-verify-ssl
 ```
 
 Default values if not provided:
 ```shell
   --foreman-url https://$hostname
-  --foreman-username admin
-  --foreman-password changeme
   --log-level INFO
   --host '127.0.0.1'
   --port 8080
@@ -43,8 +41,6 @@ Now run the container:
 ```shell
 podman run -it -p 8080:8080 foreman-mcp-server \
   --foreman-url https://my-foreman-instance.something.somewhere \
-  --foreman-username $FOREMAN_USERNAME \
-  --foreman-password $FOREMAN_PASSWORD \
   --log-level debug \
   --host localhost \
   --port 8080 \
@@ -59,7 +55,12 @@ podman run -it -p 8080:8080 foreman-mcp-server \
     "mcp": {
         "servers": {
             "foreman": {
-                "url": "http://127.0.0.1:8080/mcp/sse"
+                "url": "http://127.0.0.1:8080/mcp/sse",
+                "type": "http",
+                  "headers": {
+                    "FOREMAN_USERNAME": "login",
+                    "FOREMAN_TOKEN": "token"
+                  }
             }
         }
     },
@@ -105,7 +106,7 @@ Note: this is highly experimental. Tested in a virtual machine running CentOS St
   "mcpServers": {
     "foreman": {
       "command": "uv",
-      "args": ["--directory", "/home/$USER/foreman-mcp-server", "run","foreman-mcp-server", "--transport", "stdio"],
+      "args": ["--directory", "/home/$USER/foreman-mcp-server", "run","foreman-mcp-server", "--transport", "stdio", "--foreman-username", "login", "--foreman-password", "password/token"],
     }
   }
 }

--- a/src/foreman_mcp_server/__main__.py
+++ b/src/foreman_mcp_server/__main__.py
@@ -1,6 +1,4 @@
 from .server import main
 
 if __name__ == "__main__":
-    import sys
-
-    sys.exit(main())
+    main()

--- a/src/foreman_mcp_server/middleware/auth.py
+++ b/src/foreman_mcp_server/middleware/auth.py
@@ -1,0 +1,21 @@
+import apypie
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+class AuthMiddleware(Middleware):
+    def __init__(self, foreman_url: str):
+        self.foreman_url = foreman_url
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next):
+        # Add the foreman_api to the context for use in tools
+        if context.fastmcp_context:
+            foreman_username = context.fastmcp_context.request_context.request.headers.get("foreman_username")
+            foreman_password = context.fastmcp_context.request_context.request.headers.get("foreman_token")
+            foreman_api = apypie.ForemanApi(
+                uri=self.foreman_url,
+                username=foreman_username,
+                password=foreman_password,
+                verify_ssl=False,
+            )
+            setattr(context.fastmcp_context, 'foreman_api', foreman_api)
+
+        return await call_next(context)

--- a/src/foreman_mcp_server/middleware/auth.py
+++ b/src/foreman_mcp_server/middleware/auth.py
@@ -1,21 +1,44 @@
 import apypie
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
+
 class AuthMiddleware(Middleware):
     def __init__(self, foreman_url: str):
+        # TODO: user_map can grow indefinitely, consider using a more efficient structure or cleanup mechanism
+        self.user_map = {}
         self.foreman_url = foreman_url
 
-    async def on_call_tool(self, context: MiddlewareContext, call_next):
+    async def on_request(self, context: MiddlewareContext, call_next):
         # Add the foreman_api to the context for use in tools
         if context.fastmcp_context:
-            foreman_username = context.fastmcp_context.request_context.request.headers.get("foreman_username")
-            foreman_password = context.fastmcp_context.request_context.request.headers.get("foreman_token")
-            foreman_api = apypie.ForemanApi(
-                uri=self.foreman_url,
-                username=foreman_username,
-                password=foreman_password,
-                verify_ssl=False,
+            foreman_username = (
+                context.fastmcp_context.request_context.request.headers.get(
+                    "foreman_username"
+                )
             )
-            setattr(context.fastmcp_context, 'foreman_api', foreman_api)
+            foreman_token = context.fastmcp_context.request_context.request.headers.get(
+                "foreman_token"
+            )
+            if not foreman_username or not foreman_token:
+                raise RuntimeError(
+                    "Foreman username and token must be provided in headers."
+                )
+            session_id = context.fastmcp_context.request_context.request.headers.get(
+                "mcp-session-id"
+            )
+            if (
+                not self.user_map.get(foreman_username)
+                or session_id not in self.user_map[foreman_username]
+            ):
+                # Reset foreman_api for the user keeping the same credentials for the same session
+                foreman_api = apypie.ForemanApi(
+                    uri=self.foreman_url,
+                    username=foreman_username,
+                    password=foreman_token,
+                    verify_ssl=False,  # TODO: Make this configurable?
+                )
+                self.user_map[foreman_username] = {}
+                self.user_map[foreman_username][session_id] = foreman_api
+            context.fastmcp_context.user_map = self.user_map
 
         return await call_next(context)

--- a/src/foreman_mcp_server/middleware/auth.py
+++ b/src/foreman_mcp_server/middleware/auth.py
@@ -3,10 +3,11 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 
 class AuthMiddleware(Middleware):
-    def __init__(self, foreman_url: str):
+    def __init__(self, foreman_url: str, verify_ssl: bool = True):
         # TODO: user_map can grow indefinitely, consider using a more efficient structure or cleanup mechanism
         self.user_map = {}
         self.foreman_url = foreman_url
+        self.verify_ssl = verify_ssl
 
     async def on_request(self, context: MiddlewareContext, call_next):
         # Add the foreman_api to the context for use in tools
@@ -26,16 +27,13 @@ class AuthMiddleware(Middleware):
             session_id = context.fastmcp_context.request_context.request.headers.get(
                 "mcp-session-id"
             )
-            if (
-                not self.user_map.get(foreman_username)
-                or session_id not in self.user_map[foreman_username]
-            ):
+            if session_id not in self.user_map.get(foreman_username, {}):
                 # Reset foreman_api for the user keeping the same credentials for the same session
                 foreman_api = apypie.ForemanApi(
                     uri=self.foreman_url,
                     username=foreman_username,
                     password=foreman_token,
-                    verify_ssl=False,  # TODO: Make this configurable?
+                    verify_ssl=self.verify_ssl,
                 )
                 self.user_map[foreman_username] = {}
                 self.user_map[foreman_username][session_id] = foreman_api

--- a/src/foreman_mcp_server/middleware/logging.py
+++ b/src/foreman_mcp_server/middleware/logging.py
@@ -25,9 +25,24 @@ class LoggingMiddleware(Middleware):
             f"  Client host: {fastmcp_context.request_context.request.client.host}:{fastmcp_context.request_context.request.client.port}"
         )
         self.logger.debug(
-            f"  Client headers: {fastmcp_context.request_context.request.headers}"
+            f"  Client headers: {self._sanitize_headers(fastmcp_context.request_context.request.headers)}"
         )
         self.logger.debug(f"  Client ID: {fastmcp_context.client_id}")
         self.logger.debug(
             f"  Client params: {fastmcp_context.request_context.session.client_params}"
         )
+
+    def _sanitize_headers(self, headers):
+        """Sanitize headers to avoid logging sensitive information."""
+        sanitized_headers = {}
+        for key, value in headers.items():
+            if key.lower() in [
+                "foreman_password",
+                "foreman_token",
+                "password",
+                "token",
+            ]:
+                sanitized_headers[key] = "******"
+            else:
+                sanitized_headers[key] = value
+        return sanitized_headers

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -10,8 +10,8 @@ from .foreman_template_resources import register_foreman_template_resources
 
 def register_resources(mcp, foreman_api, get_context):
     """Register all Foreman resources with the MCP server."""
-    register_foreman_api_resources(mcp, foreman_api)
-    register_foreman_api_resource_docs(mcp, foreman_api)
+    register_foreman_api_resources(mcp, foreman_api, get_context)
+    register_foreman_api_resource_docs(mcp, foreman_api, get_context)
     register_foreman_dsl_sections(mcp, foreman_api)
-    register_foreman_dsl_docs(mcp, foreman_api)
+    register_foreman_dsl_docs(mcp, foreman_api, get_context)
     register_foreman_template_resources(mcp, foreman_api, get_context)

--- a/src/foreman_mcp_server/resources/foreman_api_resource_docs.py
+++ b/src/foreman_mcp_server/resources/foreman_api_resource_docs.py
@@ -1,7 +1,10 @@
 # TODO: Consider re-writing the cache into Markdown format.
 
 
-def register_foreman_api_resource_docs(mcp, foreman_api):
+from foreman_mcp_server.utils.utils import get_foreman_api
+
+
+def register_foreman_api_resource_docs(mcp, foreman_api, get_context):
     @mcp.resource(
         name="Foreman API Resource Documentation",
         description="Returns the documentation of a specific Foreman API resource.",
@@ -10,7 +13,8 @@ def register_foreman_api_resource_docs(mcp, foreman_api):
     )
     def foreman_api_resource_docs(resource: str) -> str:
         try:
-            docs = foreman_api.apidoc["docs"]["resources"][resource]
+            api = foreman_api or get_foreman_api(get_context)
+            docs = api.apidoc["docs"]["resources"][resource]
             return f"{docs}"
         except Exception as e:
             return f"error: Failed to read API documentation for resource '{resource}': {str(e)}"

--- a/src/foreman_mcp_server/resources/foreman_api_resources.py
+++ b/src/foreman_mcp_server/resources/foreman_api_resources.py
@@ -1,12 +1,16 @@
 # TODO: Improve metadata
 
 
-def register_foreman_api_resources(mcp, foreman_api):
+from foreman_mcp_server.utils.utils import get_foreman_api
+
+
+def register_foreman_api_resources(mcp, foreman_api, get_context):
     @mcp.resource(
         name="Foreman Resources",
         description="Provides a list of all resources available in the Foreman API.",
         uri="foreman://documentation/api/resources",
     )
     def foreman_api_resources() -> str:
-        resources = foreman_api.apidoc["docs"]["resources"].keys()
+        api = foreman_api or get_foreman_api(get_context)
+        resources = api.apidoc["docs"]["resources"].keys()
         return ", ".join(resources)

--- a/src/foreman_mcp_server/resources/foreman_dsl_docs.py
+++ b/src/foreman_mcp_server/resources/foreman_dsl_docs.py
@@ -1,7 +1,9 @@
+from foreman_mcp_server.utils.utils import get_foreman_api
+
 from ..utils.dsl_docs_utils import read_dsl_docs_from_markdown
 
 
-def register_foreman_dsl_docs(mcp, foreman_api):
+def register_foreman_dsl_docs(mcp, foreman_api, get_context):
     @mcp.resource(
         name="Foreman DSL Documentation",
         description="Reads from cache and returns the documentation of available macros for template writing in Markdown format based on provided section.",
@@ -10,8 +12,9 @@ def register_foreman_dsl_docs(mcp, foreman_api):
     )
     async def foreman_dsl_docs(section: str) -> str:
         try:
+            api = foreman_api or get_foreman_api(get_context)
             docs = await read_dsl_docs_from_markdown(
-                foreman_api.apidoc_cache_dir, f"{section}.en.md"
+                api.apidoc_cache_dir, f"{section}.en.md"
             )
             return docs
         except Exception as e:

--- a/src/foreman_mcp_server/resources/foreman_template_resources.py
+++ b/src/foreman_mcp_server/resources/foreman_template_resources.py
@@ -1,6 +1,9 @@
 # TODO: Consider refactoring
 
 
+from foreman_mcp_server.utils.utils import get_foreman_api
+
+
 def register_foreman_template_resources(mcp, foreman_api, get_context):
     @mcp.resource(
         name="Foreman Template Kinds",
@@ -11,7 +14,8 @@ def register_foreman_template_resources(mcp, foreman_api, get_context):
     async def foreman_template_kinds() -> str:
         try:
             # TODO: Consider saving it in cache. Revisit Resource notification mechanism.
-            response = foreman_api.call("template_kinds", "index", {})
+            api = foreman_api or get_foreman_api(get_context)
+            response = api.call("template_kinds", "index", {})
             kinds = [res.get("name") for res in response.get("results", [])]
             return ", ".join(kinds)
         except Exception as e:

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -68,7 +68,7 @@ def assert_server_mode(foreman_username: str, foreman_password: str, transport: 
     help="Transport protocol to use (streamable-http, stdio)",
 )
 @click.option(
-    "--verify-ssl",
+    "--verify-ssl/--no-verify-ssl",
     default=True,
     is_flag=True,
     help="Verify SSL certificates when connecting to Foreman API.",
@@ -83,7 +83,7 @@ def main(
     foreman_username: str,
     foreman_password: str,
     transport: str,
-    verify_ssl: bool = True,
+    verify_ssl: bool,
 ) -> int:
     """Run the Foreman MCP server."""
 

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -67,6 +67,12 @@ def assert_server_mode(foreman_username: str, foreman_password: str, transport: 
     default="streamable-http",
     help="Transport protocol to use (streamable-http, stdio)",
 )
+@click.option(
+    "--verify-ssl",
+    default=True,
+    is_flag=True,
+    help="Verify SSL certificates when connecting to Foreman API.",
+)
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -77,6 +83,7 @@ def main(
     foreman_username: str,
     foreman_password: str,
     transport: str,
+    verify_ssl: bool = True,
 ) -> int:
     """Run the Foreman MCP server."""
 
@@ -100,7 +107,7 @@ def main(
             uri=foreman_url,
             username=foreman_username,
             password=foreman_password,
-            verify_ssl=False,  # TODO: Make this configurable?
+            verify_ssl=verify_ssl,
         )
     register_tools(mcp, foreman_api, get_context)
     register_resources(mcp, foreman_api, get_context)
@@ -108,7 +115,7 @@ def main(
 
     # TODO: We should've probably used https://gofastmcp.com/servers/middleware#error-handling-middleware for error handling
     if transport == "streamable-http":
-        mcp.add_middleware(AuthMiddleware(foreman_url))
+        mcp.add_middleware(AuthMiddleware(foreman_url, verify_ssl))
     mcp.add_middleware(LoggingMiddleware())
 
     if transport == "stdio":

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -8,8 +8,8 @@ from fastmcp.server.dependencies import get_context
 from fastmcp.settings import LOG_LEVEL
 from fastmcp.utilities.logging import configure_logging
 
-from .middleware.logging import LoggingMiddleware
 from .middleware.auth import AuthMiddleware
+from .middleware.logging import LoggingMiddleware
 from .prompts import register_prompts
 from .resources import register_resources
 from .tools import register_tools
@@ -22,6 +22,20 @@ def normalize_log_level(_ctx, _param, value):
     if value:
         value = value.upper()
     return value
+
+
+def assert_server_mode(foreman_username: str, foreman_password: str, transport: str):
+    """Assert that the server is running in the correct mode."""
+    if transport == "streamable-http":
+        if foreman_username or foreman_password:
+            raise ValueError(
+                "Foreman username and password should not be set when using streamable-http transport."
+            )
+    else:
+        if not foreman_username or not foreman_password:
+            raise ValueError(
+                "Foreman username and password must be set when using stdio transport."
+            )
 
 
 @click.command()
@@ -40,14 +54,12 @@ def normalize_log_level(_ctx, _param, value):
 )
 @click.option(
     "--foreman-username",
-    default="admin",
-    help="Username for Foreman API authentication",
+    help="Username for Foreman API authentication. Can be set via FOREMAN_USERNAME environment variable.",
     envvar="FOREMAN_USERNAME",
 )
 @click.option(
     "--foreman-password",
-    default="changeme",
-    help="Password for Foreman API authentication",
+    help="Password for Foreman API authentication. Can be set via FOREMAN_PASSWORD environment variable. Personal access tokens are recommended.",
     envvar="FOREMAN_PASSWORD",
 )
 @click.option(
@@ -55,7 +67,9 @@ def normalize_log_level(_ctx, _param, value):
     default="streamable-http",
     help="Transport protocol to use (streamable-http, stdio)",
 )
+@click.pass_context
 def main(
+    ctx: click.Context,
     host: str,
     port: int,
     log_level: LOG_LEVEL,
@@ -66,26 +80,35 @@ def main(
 ) -> int:
     """Run the Foreman MCP server."""
 
-    mcp = FastMCP(name="Foreman MCP Server")
-
     # Default loggers
     logging.basicConfig(level=log_level)
     configure_logging(level=log_level)
     # Global logger for the MCP server
     logger = logging.getLogger("foreman_mcp_server")
     logger.setLevel(log_level)
+    try:
+        assert_server_mode(foreman_username, foreman_password, transport)
+    except ValueError as e:
+        logger.error(f"configuration: {e}")
+        ctx.exit(1)
 
-    foreman_api = apypie.ForemanApi(
-        uri=foreman_url,
-        username=foreman_username,
-        password=foreman_password,
-        verify_ssl=False,
-    )
+    mcp = FastMCP(name="Foreman MCP Server")
+
+    foreman_api = None
+    if transport == "stdio":
+        foreman_api = apypie.ForemanApi(
+            uri=foreman_url,
+            username=foreman_username,
+            password=foreman_password,
+            verify_ssl=False,  # TODO: Make this configurable?
+        )
     register_tools(mcp, foreman_api, get_context)
     register_resources(mcp, foreman_api, get_context)
     register_prompts(mcp, foreman_api, get_context)
 
-    mcp.add_middleware(AuthMiddleware(foreman_url))
+    # TODO: We should've probably used https://gofastmcp.com/servers/middleware#error-handling-middleware for error handling
+    if transport == "streamable-http":
+        mcp.add_middleware(AuthMiddleware(foreman_url))
     mcp.add_middleware(LoggingMiddleware())
 
     if transport == "stdio":
@@ -99,4 +122,4 @@ def main(
             log_level=log_level,
         )
 
-    return 0
+    ctx.exit(0)

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -9,6 +9,7 @@ from fastmcp.settings import LOG_LEVEL
 from fastmcp.utilities.logging import configure_logging
 
 from .middleware.logging import LoggingMiddleware
+from .middleware.auth import AuthMiddleware
 from .prompts import register_prompts
 from .resources import register_resources
 from .tools import register_tools
@@ -84,6 +85,7 @@ def main(
     register_resources(mcp, foreman_api, get_context)
     register_prompts(mcp, foreman_api, get_context)
 
+    mcp.add_middleware(AuthMiddleware(foreman_url))
     mcp.add_middleware(LoggingMiddleware())
 
     if transport == "stdio":

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -25,6 +25,8 @@ def register_foreman_api_methods(mcp, foreman_api, get_context):
         resource: str, action: str, params: dict
     ) -> ToolResult:
         try:
+            ctx = get_context()
+            foreman_api = getattr(ctx, 'foreman_api')
             await assert_resource(
                 resource,
                 {"name": "Resource", "list_name": "resources", "type": "api"},

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -5,7 +5,12 @@ from fastmcp.tools.tool import ToolResult
 from requests.exceptions import HTTPError
 
 from ..utils.content_utils import build_tool_result
-from ..utils.utils import assert_http_method, assert_resource, mcp_info_headers
+from ..utils.utils import (
+    assert_http_method,
+    assert_resource,
+    get_foreman_api,
+    mcp_info_headers,
+)
 
 
 # TODO: Probably split it into multiple tools (read-only, destructive, etc)
@@ -25,21 +30,18 @@ def register_foreman_api_methods(mcp, foreman_api, get_context):
         resource: str, action: str, params: dict
     ) -> ToolResult:
         try:
-            ctx = get_context()
-            foreman_api = getattr(ctx, 'foreman_api')
+            api = foreman_api or get_foreman_api(get_context)
             await assert_resource(
                 resource,
                 {"name": "Resource", "list_name": "resources", "type": "api"},
                 get_context,
             )
             assert_http_method(
-                foreman_api,
+                api,
                 {"name": action, "resource": resource, "params": params},
                 "get",
             )
-            response = foreman_api.call(
-                resource, action, params, mcp_info_headers(get_context)
-            )
+            response = api.call(resource, action, params, mcp_info_headers(get_context))
             return format_success_response(resource, action, response)
         except Exception as e:
             return format_failure_response(resource, action, e)

--- a/src/foreman_mcp_server/tools/fetch_foreman_dsl_docs.py
+++ b/src/foreman_mcp_server/tools/fetch_foreman_dsl_docs.py
@@ -2,7 +2,7 @@ from fastmcp.tools.tool import ToolResult
 
 from ..utils.content_utils import build_tool_result
 from ..utils.dsl_docs_utils import save_dsl_docs_as_markdown
-from ..utils.utils import assert_resource, mcp_info_headers
+from ..utils.utils import assert_resource, get_foreman_api, mcp_info_headers
 
 
 def register_fetch_foreman_dsl_docs(mcp, foreman_api, get_context):
@@ -22,18 +22,19 @@ def register_fetch_foreman_dsl_docs(mcp, foreman_api, get_context):
     async def fetch_foreman_dsl_docs(section: str) -> ToolResult:
         try:
             # TODO: Fix apipie-dsl since it returns all.en.json for non-existing sections
+            api = foreman_api or get_foreman_api(get_context)
             await assert_resource(
                 section,
                 {"name": "Section", "list_name": "sections", "type": "dsl"},
                 get_context,
             )
-            response = foreman_api.http_call(
+            response = api.http_call(
                 "get",
                 f"/templates_doc/v1/{section}.en.json",
                 headers=mcp_info_headers(get_context),
             )
             await save_dsl_docs_as_markdown(
-                foreman_api.apidoc_cache_dir, f"{section}.en.md", response
+                api.apidoc_cache_dir, f"{section}.en.md", response
             )
             message = f"DSL documentation for section '{section}' fetched successfully and saved to cache."
             return build_tool_result(

--- a/src/foreman_mcp_server/tools/get_foreman_api_resource_docs.py
+++ b/src/foreman_mcp_server/tools/get_foreman_api_resource_docs.py
@@ -1,7 +1,7 @@
 from fastmcp.tools.tool import ToolResult
 
 from ..utils.content_utils import build_tool_result
-from ..utils.utils import assert_resource
+from ..utils.utils import assert_resource, get_foreman_api
 
 
 def register_get_foreman_api_resource_docs(mcp, foreman_api, get_context):
@@ -20,12 +20,13 @@ def register_get_foreman_api_resource_docs(mcp, foreman_api, get_context):
     )
     async def get_foreman_api_resource_docs(resource: str) -> ToolResult:
         try:
+            api = foreman_api or get_foreman_api(get_context)
             await assert_resource(
                 resource,
                 {"name": "Resource", "list_name": "resources", "type": "api"},
                 get_context,
             )
-            docs = foreman_api.apidoc["docs"]["resources"][resource]
+            docs = api.apidoc["docs"]["resources"][resource]
             message = (
                 f"API documentation for resource '{resource}' fetched successfully"
             )

--- a/src/foreman_mcp_server/tools/get_foreman_dsl_docs.py
+++ b/src/foreman_mcp_server/tools/get_foreman_dsl_docs.py
@@ -2,7 +2,7 @@ from fastmcp.tools.tool import ToolResult
 
 from ..utils.content_utils import build_tool_result
 from ..utils.dsl_docs_utils import read_dsl_docs_from_markdown
-from ..utils.utils import assert_resource
+from ..utils.utils import assert_resource, get_foreman_api
 
 
 def register_get_foreman_dsl_docs(mcp, foreman_api, get_context):
@@ -20,13 +20,14 @@ def register_get_foreman_dsl_docs(mcp, foreman_api, get_context):
     )
     async def get_foreman_dsl_docs(section: str) -> ToolResult:
         try:
+            api = foreman_api or get_foreman_api(get_context)
             await assert_resource(
                 section,
                 {"name": "Section", "list_name": "sections", "type": "dsl"},
                 get_context,
             )
             docs = await read_dsl_docs_from_markdown(
-                foreman_api.apidoc_cache_dir, f"{section}.en.md"
+                api.apidoc_cache_dir, f"{section}.en.md"
             )
             message = f"DSL documentation for section '{section}' read successfully"
             return build_tool_result(

--- a/src/foreman_mcp_server/utils/utils.py
+++ b/src/foreman_mcp_server/utils/utils.py
@@ -1,5 +1,6 @@
 # TODO: Needs refactoring, better error handling or entire removal.
 
+from apypie import ForemanApi
 from apypie.resource import Resource
 from fastmcp.exceptions import ToolError
 
@@ -45,3 +46,16 @@ def mcp_info_headers(get_context) -> dict:
             "mcp-session-id"
         ),
     }
+
+
+def get_foreman_api(get_context) -> ForemanApi:
+    """Retrieves the Foreman API instance for the given username."""
+
+    ctx = get_context()
+    foreman_username = ctx.request_context.request.headers.get("foreman_username")
+    session_id = ctx.request_context.request.headers.get("mcp-session-id")
+    user_map = getattr(ctx, "user_map", {})
+
+    if foreman_username in user_map and session_id in user_map[foreman_username]:
+        return user_map[foreman_username][session_id]
+    raise RuntimeError(f"Foreman API is not available for {foreman_username}.")


### PR DESCRIPTION
I know this is... ridiculous, but just an idea to test. Since the clients need to create a basic config (url/port/type), some of them support headers. We could send via headers basic auth info (like username and access token) and use it within mcp server to call the API. The server becomes user-less on its own, it should behave based on connected client. @adamruzicka , WDYT?