### PR TITLE
Do not explicitly install build requirements

### DIFF
--- a/Containerfile.ubi9
+++ b/Containerfile.ubi9
@@ -13,8 +13,7 @@ COPY --chown=1001:0 requirements.txt requirements-build.txt pyproject.toml ./
 COPY --chown=1001:0 src src
 COPY --chown=1001:0 README.md .
 
-RUN pip install -r requirements-build.txt && \
-    pip install -r requirements.txt && \
+RUN pip install -r requirements.txt && \
     pip install .
 
 LABEL url="https://www.redhat.com"


### PR DESCRIPTION
Assumption:
- we explicitly install build dependencies
- a single dependency is needed in two different versions
- if we don't pull build deps in explicitly, maybe the right ones will be selected at appropriate time?