### PR TITLE
Add barebones hammer tool and resources

### DIFF
--- a/src/foreman_mcp_server/data/hammer_basic_information.md
+++ b/src/foreman_mcp_server/data/hammer_basic_information.md
@@ -1,0 +1,22 @@
+# Hammer CLI Documentation
+Hammer CLI is the command line interface for Foreman and Katello.
+
+## Full Documentation URLs
+- Nightly docs: https://docs.theforeman.org/nightly/Hammer_CLI/index-katello.html
+- Foreman 3.16 (Katello 4.18): https://docs.theforeman.org/3.16/Hammer_CLI/index-katello.html
+- Foreman 3.15 (Katello 4.17): https://docs.theforeman.org/3.15/Hammer_CLI/index-katello.html
+- Older versions of Foreman/Katello are unsupported.
+
+## Basic Usage
+To get help for any hammer command, use:
+- `hammer --help` - Show all available subcommands
+- `hammer <subcommand> --help` - Show help for a specific subcommand
+- `hammer <subcommand> <action> --help` - Show help for a specific action
+
+## Common Subcommands
+- TODO
+
+## Examples
+- `hammer --help` - Display all possible subcommands
+
+For detailed documentation, use hammer_web_documentation to fetch the nightly hammer docs or use the execute_hammer tool with appropriate help commands.

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -3,6 +3,8 @@ from .foreman_api_resources import register_foreman_api_resources
 from .foreman_dsl_docs import register_foreman_dsl_docs
 from .foreman_dsl_sections import register_foreman_dsl_sections
 from .foreman_template_resources import register_foreman_template_resources
+from .hammer_docs import register_hammer_docs
+from .hammer_resources import register_hammer_resources
 
 # TODO: For some resources consider refactoring: fetch_resource tool, search_resource tool.
 # TODO: Maybe local logs can be a resource?
@@ -15,3 +17,5 @@ def register_resources(mcp, foreman_api, get_context):
     register_foreman_dsl_sections(mcp, foreman_api)
     register_foreman_dsl_docs(mcp, foreman_api, get_context)
     register_foreman_template_resources(mcp, foreman_api, get_context)
+    register_hammer_docs(mcp)
+    register_hammer_resources(mcp)

--- a/src/foreman_mcp_server/resources/hammer_docs.py
+++ b/src/foreman_mcp_server/resources/hammer_docs.py
@@ -1,0 +1,49 @@
+from importlib.resources import files
+
+import aiofiles
+import httpx
+
+
+def register_hammer_docs(mcp):
+    """Register Hammer CLI documentation resource."""
+
+    @mcp.resource(
+        name="Hammer CLI Basic Information",
+        description="Provides basic information about Hammer CLI, including usage and common commands.",
+        uri="hammer://basic-information",
+        mime_type="text/markdown",
+    )
+    async def hammer_basic_information() -> str:
+        try:
+            data_path = files("foreman_mcp_server").joinpath(
+                "data/hammer_basic_information.md"
+            )
+            async with aiofiles.open(data_path) as f:
+                return await f.read()
+        except FileNotFoundError:
+            return "error: Hammer CLI basic information file not found."
+        except Exception as e:
+            return f"error: Failed to read Hammer CLI basic information: {str(e)}"
+
+    @mcp.resource(
+        name="Hammer CLI Documentation Webpage",
+        description="Provides access to Hammer CLI documentation from docs.theforeman.org. This resource contains information on nearly all Hammer CLI commands and their usage.",
+        uri="hammer://web-documentation",
+        mime_type="text/html",
+    )
+    async def hammer_web_documentation() -> str:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    "https://docs.theforeman.org/nightly/Hammer_CLI/index-katello.html",
+                    follow_redirects=True,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                return response.text
+        except httpx.HTTPStatusError as e:
+            return f"error: HTTP error {e.response.status_code} while fetching Hammer CLI documentation"
+        except httpx.RequestError as e:
+            return f"error: Request failed while fetching Hammer CLI documentation: {str(e)}"
+        except Exception as e:
+            return f"error: Failed to fetch Hammer CLI documentation: {str(e)}"

--- a/src/foreman_mcp_server/resources/hammer_resources.py
+++ b/src/foreman_mcp_server/resources/hammer_resources.py
@@ -1,0 +1,12 @@
+from ..utils.hammer_utils import execute_hammer_command_for_resource
+
+
+def register_hammer_resources(mcp):
+    @mcp.resource(
+        name="Hammer CLI Full Help",
+        description="Prints help for all available hammer commands, subcommands, and actions.",
+        uri="hammer://full-help",
+        mime_type="text/plain",
+    )
+    async def hammer_full_help() -> str:
+        return await execute_hammer_command_for_resource("full-help")

--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -1,9 +1,9 @@
 from .call_foreman_api import register_foreman_api_methods
+from .call_hammer_commands import register_hammer_commands
 from .fetch_foreman_dsl_docs import register_fetch_foreman_dsl_docs
 from .get_foreman_api_resource_docs import register_get_foreman_api_resource_docs
 from .get_foreman_dsl_docs import register_get_foreman_dsl_docs
 
-# TODO: Maybe hammer can be a tool?
 # TODO: Maybe foreman-maintain can be a tool?
 
 
@@ -15,3 +15,4 @@ def register_tools(mcp, foreman_api, get_context):
     # TODO: Remove when Claude Desktop supports Resource with parameters
     register_get_foreman_api_resource_docs(mcp, foreman_api, get_context)
     register_get_foreman_dsl_docs(mcp, foreman_api, get_context)
+    register_hammer_commands(mcp)

--- a/src/foreman_mcp_server/tools/call_hammer_commands.py
+++ b/src/foreman_mcp_server/tools/call_hammer_commands.py
@@ -1,0 +1,23 @@
+from fastmcp.tools.tool import ToolResult
+
+from ..utils.hammer_utils import (
+    execute_hammer_command_for_tool,
+)
+
+
+def register_hammer_commands(mcp):
+    @mcp.tool(
+        description="Execute a hammer CLI command with any arguments and return its output. Use "
+        "this ONLY when the user explicitly wants to execute a command on the MCP server's "
+        "environment. A leading 'hammer' is NOT required in the command.",
+        tags=("hammer", "cli", "command", "local"),
+        annotations={
+            "title": "Execute Hammer CLI Command",
+            "readOnlyHint": False,
+            "destructiveHint": True,  # Hammer can be destructive
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def execute_hammer(command: str) -> ToolResult:
+        return await execute_hammer_command_for_tool(command)

--- a/src/foreman_mcp_server/utils/hammer_utils.py
+++ b/src/foreman_mcp_server/utils/hammer_utils.py
@@ -1,0 +1,73 @@
+import asyncio
+import shlex
+
+from fastmcp.tools.tool import ToolResult
+
+from foreman_mcp_server.utils.content_utils import build_tool_result
+
+
+def build_success_structured_content(
+    command: str, output: str, returncode: int
+) -> dict:
+    """Build structured content for a successful hammer command execution."""
+    return {
+        "message": f"Hammer command executed successfully: hammer {command}",
+        "command": f"hammer {command}",
+        "output": output,
+        "returncode": returncode,
+    }
+
+
+def build_failure_structured_content(
+    command: str, output: str, error: str, returncode: int
+) -> dict:
+    """Build structured content for a failed hammer command execution."""
+    return {
+        "message": f"Hammer command failed: hammer {command}",
+        "command": f"hammer {command}",
+        "output": output,
+        "error": error,
+        "returncode": returncode,
+    }
+
+
+async def execute_hammer_command_for_tool(command: str) -> ToolResult:
+    process = await asyncio.create_subprocess_exec(
+        "hammer",
+        *shlex.split(command),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate()
+
+    # Decode output
+    stdout_text = stdout.decode("utf-8") if stdout else ""
+    stderr_text = stderr.decode("utf-8") if stderr else ""
+
+    if process.returncode == 0:
+        return build_tool_result(
+            build_success_structured_content(command, stdout_text, process.returncode)
+        )
+    else:
+        return build_tool_result(
+            build_failure_structured_content(
+                command, stdout_text, stderr_text, process.returncode
+            )
+        )
+
+
+async def execute_hammer_command_for_resource(command: str) -> str:
+    process = await asyncio.create_subprocess_exec(
+        "hammer",
+        *shlex.split(command),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate()
+
+    if process.returncode == 0:
+        return stdout.decode("utf-8")
+    else:
+        return f"error: Hammer CLI command failed with error: {stderr.decode('utf-8')}"


### PR DESCRIPTION
This PR adds bare-bones version of hammer support to the ForemanMCP server. This includes a basic 'hammer command' tool where the AI can input any hammer-cli command. It also includes the following resources:
- A small, quick resource briefly explaining the purpose and syntax of hammer.
- A resource which fetches the current hammer nightly docs.
- A resource which runs `hammer full-help` and returns the result.

**Setting up your environment for this PR:**
1. Launch your Foreman/Katello server.
2. Get the MCP server running (change hostname):
```
$ sudo dnf install python-devel
$ pip3 install uv
$ uv run foreman-mcp-server --foreman-url https://centos9-katello-devel.redhat.example.com --log-level debug --no-verify-ssl
```
3. Add the following to your `~/claude.json` file to add Claude support for the MCP server:
```
{
  "projects": {
    "/home/quinn/foreman-mcp-server": {
      "mcpServers": {
        "foreman": {
          "type": "http",
          "url": "http://localhost:8080/mcp",
          "headers": {
            "FOREMAN_USERNAME": "admin",
            "FOREMAN_TOKEN": "foo"
          }
        }
      }
    }
  }
}
```
4. Add the Foreman nightly repo (`etc/yum.repos.d/foreman.repo`)
```
[foreman]
name=Foreman Nightly
baseurl=[https://yum.theforeman.org/nightly/el9/x86_64](https://yum.theforeman.org/nightly/el9/x86_64)
gpgcheck=0
enabled=1
```
5. Install hammer locally on path
```
$ sudo dnf install rubygem-hammer_cli rubygem-hammer_cli_foreman ruby-devel gcc make
$ sudo gem install hammer_cli_katello
$ hammer --help
```
6. Set up your `~/.hammer/cli_config.yml` as shown (change hostname):
```
:modules:
  - hammer_cli_foreman
  - hammer_cli_katello

:foreman:
  :enable_module: true
  :host: 'https://centos9-katello-devel.redhat.example.com'
  :verify_ssl: false
  :username: admin
  :password: changeme

:katello:
  :enable_module: true

:log_dir: '~/.hammer/log'
:log_level: 'debug'
```
7. Fetch your CA cert and install (change hostname):
```
$ hammer --fetch-ca-cert https://centos9-katello-devel.redhat.example.com
$ sudo install /home/quinn/.hammer/certs/centos9-katello-devel.redhat.example.com_443.pem /etc/pki/ca-trust/source/anchors/ 
$ sudo update-ca-trust
$ hammer --help
```
8. Make sure your hammer is authenticated and can run normal hammer commands.
9. Launch Claude with `claude`.
10. Launch the MCP inspector:
```
$ sudo dnf install nodejs
$ npx @modelcontextprotocol/inspector
```

**Testing this PR:**
1. Start in the MCP inspector. Set your transport type to "Streamable HTTP", your URL to `http://localhost:8080/mcp`, and your connection type to "Via Proxy".
2. Open the Authentication dropdown and add two headers:
	1. `foreman_username`: `admin`
	2. `foreman_token`: `foo`
	These headers aren't required for hammer to function (since hammer auth is handled in the hammer config file) but they are required for the other ForemanMCP functionality.
3. Click connect. The server should now be connected.
4. Click on 'Resources' -> 'List Resources'. Verify these resources return usable information when called:
	1. "Hammer CLI Basic Information"
	2. "Hammer CLI Documentation Webpage"
	3. "Hammer CLI Full Help" <- This calls an actual hammer command. Ensure it returns the full help for EVERYTHING (could take a sec).
5. Click on 'Tools' -> 'List Tools' -> 'Execute Hammer'. Try a bunch of hammer commands and ensure the outputs make sense.
6. Open Claude. Type `/mcp` and you should see `foreman` as "connected". Navigate the MCP server and you should see that the `execute_hammer_command` tool is available. 
7. Try asking Claude to generate AND execute some hammer commands.