### PR TITLE
Place everything under /app in ubi9 images

### DIFF
--- a/Containerfile.ubi9
+++ b/Containerfile.ubi9
@@ -7,6 +7,9 @@ COPY LICENSE /licenses
 
 RUN microdnf install -y cargo libffi-devel openssl-devel python3.12-devel
 
+RUN mkdir app
+WORKDIR /app
+
 USER 1001
 
 COPY --chown=1001:0 requirements.txt requirements-build.txt pyproject.toml ./


### PR DESCRIPTION
With the centos-based images we place everything under `/app`, while the ubi9 relied on the workdir set by the parent image (`/opt/app-root/src`). This required CA bundle to be placed into different locations, depending on which variant of the image was used unless explicitly pointed at the in-container location of the bundle.

There are other ways how we could go about this

1. place a dangling symlink to `/opt/app-root/src/ca.pem` pointing at `/app/ca.pem` so that it could be placed into either location
2. leave the sources in the default dir and change it afterwards), but this brings the different flavours closer together
3. Set the FOREMAN_CA_BUNDLE env var in the containerfile