### PR TITLE
Add hammer org support

### DIFF
--- a/src/foreman_mcp_server/data/hammer_basic_information.md
+++ b/src/foreman_mcp_server/data/hammer_basic_information.md
@@ -14,7 +14,7 @@ To get help for any hammer command, use:
 - `hammer <subcommand> <action> --help` - Show help for a specific action
 
 ## Common Subcommands
-- TODO
+- `hammer organization` - See the `hammer_organization_info` resource for more information
 
 ## Examples
 - `hammer --help` - Display all possible subcommands

--- a/src/foreman_mcp_server/data/hammer_basic_information.md
+++ b/src/foreman_mcp_server/data/hammer_basic_information.md
@@ -1,0 +1,22 @@
+# Hammer CLI Documentation
+Hammer CLI is the command line interface for Foreman and Katello.
+
+## Full Documentation URLs
+- Nightly docs: https://docs.theforeman.org/nightly/Hammer_CLI/index-katello.html
+- Foreman 3.16 (Katello 4.18): https://docs.theforeman.org/3.16/Hammer_CLI/index-katello.html
+- Foreman 3.15 (Katello 4.17): https://docs.theforeman.org/3.15/Hammer_CLI/index-katello.html
+- Older versions of Foreman/Katello are unsupported.
+
+## Basic Usage
+To get help for any hammer command, use:
+- `hammer --help` - Show all available subcommands
+- `hammer <subcommand> --help` - Show help for a specific subcommand
+- `hammer <subcommand> <action> --help` - Show help for a specific action
+
+## Common Subcommands
+- TODO
+
+## Examples
+- `hammer --help` - Display all possible subcommands
+
+For detailed documentation, use hammer_web_documentation to fetch the nightly hammer docs or use the execute_hammer tool with appropriate help commands.

--- a/src/foreman_mcp_server/data/hammer_organization_help.md
+++ b/src/foreman_mcp_server/data/hammer_organization_help.md
@@ -1,0 +1,314 @@
+# Hammer Organization Information
+What follows is the output of various `hammer organization --help` commands (as of nightly branch 2025-11-10),
+demonstrating the flags each `hammer organization` action takes as parameters. Instructions are provided on
+how to call each action through ForemanMCP.
+
+## `hammer organization`
+This subcommand can be executed with any actions and parameters using the `execute_hammer` tool.
+Example `hammer organization --help`
+```
+$ hammer organization --help
+Usage:
+    hammer organization [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+ SUBCOMMAND                    Subcommand
+ [ARG] ...                     Subcommand arguments
+
+Subcommands:
+ add-compute-resource          Associate a compute resource
+ add-domain                    Associate a domain
+ add-hostgroup                 Associate a hostgroup
+ add-location                  Associate a location
+ add-medium                    Associate a medium
+ add-provisioning-template     Associate provisioning templates
+ add-smart-proxy               Associate a smart proxy
+ add-subnet                    Associate a subnet
+ add-user                      Associate an user
+ configure-cdn                 Update the CDN configuration
+ create                        Create organization
+ delete                        Delete an organization
+ delete-parameter              Delete parameter for an organization
+ info                          Show organization
+ list                          List all organizations
+ remove-compute-resource       Disassociate a compute resource
+ remove-domain                 Disassociate a domain
+ remove-hostgroup              Disassociate a hostgroup
+ remove-location               Disassociate a location
+ remove-medium                 Disassociate a medium
+ remove-provisioning-template  Disassociate provisioning templates
+ remove-smart-proxy            Disassociate a smart proxy
+ remove-subnet                 Disassociate a subnet
+ remove-user                   Disassociate an user
+ set-parameter                 Create or update parameter for an organization
+ update                        Update organization
+
+Options:
+ -h, --help                    Print help
+```
+
+## `hammer organization create`
+This subcommand can be executed using the `execute_hammer` tool.
+```
+$ hammer organization create --help
+Usage:
+    hammer organization create [OPTIONS]
+
+Options:
+ --compute-resource[s|-ids] LIST                Compute resource names/ids
+ --description VALUE
+ --domain[s|-ids] LIST                          Domain names/ids
+ --environment-ids LIST                         Environment ids
+ --hostgroup[s|-ids|-titles] LIST               Host group names/titles/ids
+ --ignore-types LIST                            List of resources types that will be automatically associated
+ --label VALUE
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --location[s|-ids|-titles] LIST                Associated location names/titles/ids
+ --medi[a|um-ids] LIST                          Medium names/ids
+ --name VALUE
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --partition-table[s|-ids] LIST                 Partition template names/ids
+ --provisioning-template[s|-ids] LIST           Provisioning template names/ids
+ --realm[s|-ids] LIST                           Realm names/ids
+ --smart-prox[ies|y-ids] LIST                   Smart proxy names/ids
+ --subnet[s|-ids] LIST                          Subnet names/ids
+ --user[s|-ids] LIST                            User logins/ids
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization delete`
+This subcommand can be executed using the `execute_hammer` tool.
+```
+$ hammer organization delete --help
+Usage:
+    hammer organization <delete|destroy> [OPTIONS]
+
+Options:
+ --async                                        Do not wait for the task
+ --id VALUE
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --name VALUE                                   Set the current organization context for the request
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --title VALUE                                  Set the current organization context for the request
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization info`
+This subcommand can be generated using the `generate_hammer_organization_info` resource and can be executed using the `execute_hammer_organization_info` resource. Info by ID or info containing non-default fields requires the use of the `execute_hammer` tool.
+```
+$ hammer organization info --help
+Usage:
+    hammer organization <info|show> [OPTIONS]
+
+Options:
+ --fields LIST                                  Show specified fields or predefined field sets only. (See below)
+ --id VALUE
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --name VALUE                                   Set the current organization context for the request
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --title VALUE                                  Set the current organization context for the request
+ -h, --help                                     Print help
+
+Predefined field sets:
+  -------------------------------------------------|-----|---------|-----
+  FIELDS                                           | ALL | DEFAULT | THIN
+  -------------------------------------------------|-----|---------|-----
+  Id                                               | x   | x       | x
+  Title                                            | x   | x       | x
+  Name                                             | x   | x       | x
+  Description                                      | x   | x       |
+  Parent                                           | x   | x       |
+  Users/                                           | x   | x       |
+  Smart proxies/                                   | x   | x       |
+  Subnets/                                         | x   | x       |
+  Compute resources/                               | x   | x       |
+  Installation media/                              | x   | x       |
+  Templates/                                       | x   | x       |
+  Partition tables/                                | x   | x       |
+  Domains/                                         | x   | x       |
+  Realms/                                          | x   | x       |
+  Hostgroups/                                      | x   | x       |
+  Parameters/                                      | x   | x       |
+  Locations/                                       | x   | x       |
+  Created at                                       | x   | x       |
+  Updated at                                       | x   | x       |
+  Label                                            | x   | x       | x
+  Description                                      | x   | x       |
+  Service levels                                   | x   | x       |
+  Cdn configuration/type                           | x   | x       |
+  Cdn configuration/url                            | x   | x       |
+  Cdn configuration/upstream organization          | x   | x       |
+  Cdn configuration/upstream lifecycle environment | x   | x       |
+  Cdn configuration/upstream content view          | x   | x       |
+  Cdn configuration/username                       | x   | x       |
+  Cdn configuration/ssl ca credential id           | x   | x       |
+  -------------------------------------------------|-----|---------|-----
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization list`
+This subcommand can be generated using the `generate_hammer_organization_list` resource and can be executed using the `execute_hammer_organization_list` resource. Passing in parameters requires use of the `execute_hammer` tool.
+```
+$ hammer organization list --help
+Usage:
+    hammer organization <list|index> [OPTIONS]
+
+Options:
+ --fields LIST                                  Show specified fields or predefined field sets only. (See below)
+ --full-result BOOLEAN                          Whether or not to show all results
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --order VALUE                                  Sort field and order, eg. 'id DESC'
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --page NUMBER                                  Page number, starting at 1
+ --per-page NUMBER                              Number of results per page to return
+ --search VALUE                                 Search string
+ --sort-by VALUE                                Field to sort the results on
+ --sort-order VALUE                             How to order the sorted results (e.g. ASC for ascending)
+ -h, --help                                     Print help
+
+Predefined field sets:
+  ------------|-----|---------|-----
+  FIELDS      | ALL | DEFAULT | THIN
+  ------------|-----|---------|-----
+  Id          | x   | x       | x
+  Title       | x   | x       | x
+  Name        | x   | x       | x
+  Description | x   | x       |
+  Label       | x   | x       | x
+  ------------|-----|---------|-----
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+
+Search / Order fields:
+  description         text
+  id                  integer
+  label               string
+  name                string
+  organization_id     integer
+  title               string
+```
+
+## `hammer organization update`
+This subcommand can be executed using the `execute_hammer` tool.
+Example: `hammer organization update --name "Old Name" --new-name "New Name"`
+```
+$ hammer organization update --help
+Usage:
+    hammer organization update [OPTIONS]
+
+Options:
+ --compute-resource[s|-ids] LIST                Compute resource names/ids
+ --description VALUE
+ --domain[s|-ids] LIST                          Domain names/ids
+ --environment-ids LIST                         Environment ids
+ --hostgroup[s|-ids|-titles] LIST               Host group names/titles/ids
+ --id VALUE
+ --ignore-types LIST                            List of resources types that will be automatically associated
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --location[s|-ids|-titles] LIST                Associated location names/titles/ids
+ --medi[a|um-ids] LIST                          Medium names/ids
+ --name VALUE
+ --new-name VALUE
+ --new-title VALUE
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --partition-table[s|-ids] LIST                 Partition template names/ids
+ --provisioning-template[s|-ids] LIST           Provisioning template names/ids
+ --realm[s|-ids] LIST                           Realm names/ids
+ --redhat-repository-url VALUE                  Red Hat CDN URL
+ --smart-prox[ies|y-ids] LIST                   Smart proxy names/ids
+ --subnet[s|-ids] LIST                          Subnet names/ids
+ --title VALUE                                  Set the current organization context for the request
+ --user[s|-ids] LIST                            User logins/ids
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## Other Actions
+For other organization actions (add-*, remove-*, set-parameter, delete-parameter, configure-cdn, etc.), use the `execute_hammer` tool with the appropriate parameters. You can get help for any specific action by running:
+```
+hammer organization <action> --help
+```

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -3,6 +3,7 @@ from .foreman_api_resources import register_foreman_api_resources
 from .foreman_dsl_docs import register_foreman_dsl_docs
 from .foreman_dsl_sections import register_foreman_dsl_sections
 from .foreman_template_resources import register_foreman_template_resources
+from .hammer_docs import register_hammer_docs
 
 # TODO: For some resources consider refactoring: fetch_resource tool, search_resource tool.
 # TODO: Maybe local logs can be a resource?
@@ -15,3 +16,4 @@ def register_resources(mcp, foreman_api, get_context):
     register_foreman_dsl_sections(mcp, foreman_api)
     register_foreman_dsl_docs(mcp, foreman_api, get_context)
     register_foreman_template_resources(mcp, foreman_api, get_context)
+    register_hammer_docs(mcp, foreman_api, get_context)

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -4,6 +4,7 @@ from .foreman_dsl_docs import register_foreman_dsl_docs
 from .foreman_dsl_sections import register_foreman_dsl_sections
 from .foreman_template_resources import register_foreman_template_resources
 from .hammer_docs import register_hammer_docs
+from .hammer_resources import register_hammer_resources
 
 # TODO: For some resources consider refactoring: fetch_resource tool, search_resource tool.
 # TODO: Maybe local logs can be a resource?
@@ -17,3 +18,4 @@ def register_resources(mcp, foreman_api, get_context):
     register_foreman_dsl_docs(mcp, foreman_api, get_context)
     register_foreman_template_resources(mcp, foreman_api, get_context)
     register_hammer_docs(mcp, foreman_api, get_context)
+    register_hammer_resources(mcp, foreman_api, get_context)

--- a/src/foreman_mcp_server/resources/hammer_docs.py
+++ b/src/foreman_mcp_server/resources/hammer_docs.py
@@ -1,0 +1,71 @@
+import asyncio
+from importlib.resources import files
+
+import aiofiles
+import httpx
+
+
+def register_hammer_docs(mcp, _foreman_api, _get_context):
+    """Register Hammer CLI documentation resource."""
+
+    @mcp.resource(
+        name="Hammer CLI Basic Information",
+        description="Provides basic information about Hammer CLI, including usage and common commands.",
+        uri="hammer://basic-information",
+        mime_type="text/markdown",
+    )
+    async def hammer_basic_information() -> str:
+        try:
+            data_path = files("foreman_mcp_server").joinpath(
+                "data/hammer_basic_information.md"
+            )
+            async with aiofiles.open(data_path) as f:
+                return await f.read()
+        except FileNotFoundError:
+            return "error: Hammer CLI basic information file not found."
+        except Exception as e:
+            return f"error: Failed to read Hammer CLI basic information: {str(e)}"
+
+    @mcp.resource(
+        name="Hammer CLI Documentation Webpage",
+        description="Provides access to Hammer CLI documentation from docs.theforeman.org. This resource contains information on nearly all Hammer CLI commands and their usage.",
+        uri="hammer://web-documentation",
+        mime_type="text/html",
+    )
+    async def hammer_web_documentation() -> str:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    "https://docs.theforeman.org/nightly/Hammer_CLI/index-katello.html",
+                    follow_redirects=True,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                return response.text
+        except httpx.HTTPStatusError as e:
+            return f"error: HTTP error {e.response.status_code} while fetching Hammer CLI documentation"
+        except httpx.RequestError as e:
+            return f"error: Request failed while fetching Hammer CLI documentation: {str(e)}"
+        except Exception as e:
+            return f"error: Failed to fetch Hammer CLI documentation: {str(e)}"
+
+    @mcp.resource(
+        name="Hammer CLI Full Help",
+        description="Prints help for all available hammer commands, subcommands, and actions.",
+        uri="hammer://full-help",
+        mime_type="text/plain",
+    )
+    async def hammer_full_help() -> str:
+        process = await asyncio.create_subprocess_exec(
+            "hammer",
+            "full-help",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdout, stderr = await process.communicate()
+
+        if process.returncode == 0:
+            return stdout.decode("utf-8")
+        else:
+            return f"error: Hammer CLI help command failed with error: {stderr.decode('utf-8')}"

--- a/src/foreman_mcp_server/resources/hammer_docs.py
+++ b/src/foreman_mcp_server/resources/hammer_docs.py
@@ -69,3 +69,21 @@ def register_hammer_docs(mcp, _foreman_api, _get_context):
             return stdout.decode("utf-8")
         else:
             return f"error: Hammer CLI help command failed with error: {stderr.decode('utf-8')}"
+
+    @mcp.resource(
+        name="Hammer CLI Organization Info",
+        description="Provides detailed information on actions and parameters within the `hammer organization` subcommand.",
+        uri="hammer://organization-info",
+        mime_type="text/markdown",
+    )
+    async def hammer_organization_info() -> str:
+        try:
+            data_path = files("foreman_mcp_server").joinpath(
+                "data/hammer_organization_help.md"
+            )
+            async with aiofiles.open(data_path) as f:
+                return await f.read()
+        except FileNotFoundError:
+            return "error: Hammer CLI organization help file not found."
+        except Exception as e:
+            return f"error: Failed to read Hammer CLI organization help: {str(e)}"

--- a/src/foreman_mcp_server/resources/hammer_resources.py
+++ b/src/foreman_mcp_server/resources/hammer_resources.py
@@ -1,0 +1,86 @@
+from ..utils.hammer_utils import (
+    execute_hammer_command,
+    get_user_credentials,
+    organization_info_command,
+    organization_list_command,
+)
+
+
+def register_hammer_resources(mcp, foreman_api, get_context):
+    """Register Hammer CLI resources for read-only operations."""
+
+    # Generate resources - return command strings without executing
+    @mcp.resource(
+        name="Generate Hammer Organization List Command",
+        description="Generates a hammer command for listing organizations. Does not execute the command.",
+        uri="hammer://generate-organization-list",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_list() -> str:
+        """Returns the hammer command string for listing organizations."""
+        return f"hammer {organization_list_command()}"
+
+    @mcp.resource(
+        name="Generate Hammer Organization Info Command",
+        description="Generates a hammer command for getting organization information. Does not execute the command.",
+        uri="hammer://generate-organization-info/{name}",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_info(name: str) -> str:
+        """
+        Returns the hammer command string for getting organization info.
+
+        Args:
+            name: Organization name
+        """
+        return f"hammer {organization_info_command(name)}"
+
+    # Execute resources - run commands and return output
+    @mcp.resource(
+        name="Execute Hammer Organization List",
+        description="Executes the hammer command to list all organizations and returns the output. "
+        "Supports multi-user: in streamable-http mode uses per-user credentials from headers, "
+        "in stdio mode uses credentials from ~/.hammer/cli_config.yml or startup args.",
+        uri="hammer://execute-organization-list",
+        mime_type="text/plain",
+    )
+    async def execute_hammer_organization_list() -> str:
+        """Returns list of all organizations."""
+        username, password, foreman_url = get_user_credentials(get_context, foreman_api)
+        command = organization_list_command()
+        success, output, *rest = await execute_hammer_command(
+            command, username, password, foreman_url
+        )
+        if success:
+            return output
+        else:
+            error = rest[0] if rest else ""
+            return f"Error executing command 'hammer {command}':\n{error}"
+
+    @mcp.resource(
+        name="Execute Hammer Organization Info",
+        description="Executes the hammer command to get detailed organization information and returns the output. "
+        "Provides complete details including name, label, description, users, smart proxies, "
+        "subnets, compute resources, media, templates, domains, environments, locations, and "
+        "parameters. Supports multi-user: in streamable-http mode uses per-user credentials "
+        "from headers, in stdio mode uses credentials from ~/.hammer/cli_config.yml or startup args.",
+        uri="hammer://execute-organization-info/{name}",
+        mime_type="text/plain",
+    )
+    async def execute_hammer_organization_info(name: str) -> str:
+        """
+        Returns detailed information about an organization.
+
+        Args:
+            name: Organization name
+        """
+        username, password, foreman_url = get_user_credentials(get_context, foreman_api)
+        command = organization_info_command(name)
+        success, output, *rest = await execute_hammer_command(
+            command, username, password, foreman_url
+        )
+        if success:
+            return output
+        else:
+            error = rest[0] if rest else ""
+            return f"Error executing command 'hammer {command}':\n{error}"

--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -1,4 +1,5 @@
 from .call_foreman_api import register_foreman_api_methods
+from .call_hammer_commands import register_hammer_commands
 from .fetch_foreman_dsl_docs import register_fetch_foreman_dsl_docs
 from .get_foreman_api_resource_docs import register_get_foreman_api_resource_docs
 from .get_foreman_dsl_docs import register_get_foreman_dsl_docs
@@ -15,3 +16,4 @@ def register_tools(mcp, foreman_api, get_context):
     # TODO: Remove when Claude Desktop supports Resource with parameters
     register_get_foreman_api_resource_docs(mcp, foreman_api, get_context)
     register_get_foreman_dsl_docs(mcp, foreman_api, get_context)
+    register_hammer_commands(mcp, foreman_api, get_context)

--- a/src/foreman_mcp_server/tools/call_hammer_commands.py
+++ b/src/foreman_mcp_server/tools/call_hammer_commands.py
@@ -1,8 +1,7 @@
-import asyncio
-
 from fastmcp.tools.tool import ToolResult
 
 from ..utils.content_utils import build_tool_result
+from ..utils.hammer_utils import execute_hammer_command, get_user_credentials
 
 
 def build_success_structured_content(
@@ -30,7 +29,7 @@ def build_failure_structured_content(
     }
 
 
-def register_hammer_commands(mcp, _foreman_api, _get_context):
+def register_hammer_commands(mcp, foreman_api, _get_context):
     """Register hammer CLI command execution tools."""
 
     @mcp.tool(
@@ -48,28 +47,24 @@ def register_hammer_commands(mcp, _foreman_api, _get_context):
         },
     )
     async def execute_hammer(command: str) -> ToolResult:
-        process = await asyncio.create_subprocess_exec(
-            "hammer",
-            *command.split(),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        # Get user credentials
+        username, password, foreman_url = get_user_credentials(
+            _get_context, foreman_api
         )
 
-        stdout, stderr = await process.communicate()
+        # Execute hammer command using shared utility
+        success, output, *rest = await execute_hammer_command(
+            command, username, password, foreman_url
+        )
 
-        # Decode output
-        stdout_text = stdout.decode("utf-8") if stdout else ""
-        stderr_text = stderr.decode("utf-8") if stderr else ""
-
-        if process.returncode == 0:
+        if success:
+            returncode = rest[0] if rest else 0
             return build_tool_result(
-                build_success_structured_content(
-                    command, stdout_text, process.returncode
-                )
+                build_success_structured_content(command, output, returncode)
             )
         else:
+            error = rest[0] if rest else ""
+            returncode = rest[1] if len(rest) > 1 else 1
             return build_tool_result(
-                build_failure_structured_content(
-                    command, stdout_text, stderr_text, process.returncode
-                )
+                build_failure_structured_content(command, output, error, returncode)
             )

--- a/src/foreman_mcp_server/tools/call_hammer_commands.py
+++ b/src/foreman_mcp_server/tools/call_hammer_commands.py
@@ -1,0 +1,75 @@
+import asyncio
+
+from fastmcp.tools.tool import ToolResult
+
+from ..utils.content_utils import build_tool_result
+
+
+def build_success_structured_content(
+    command: str, output: str, returncode: int
+) -> dict:
+    """Build structured content for a successful hammer command execution."""
+    return {
+        "message": f"Hammer command executed successfully: hammer {command}",
+        "command": f"hammer {command}",
+        "output": output,
+        "returncode": returncode,
+    }
+
+
+def build_failure_structured_content(
+    command: str, output: str, error: str, returncode: int
+) -> dict:
+    """Build structured content for a failed hammer command execution."""
+    return {
+        "message": f"Hammer command failed: hammer {command}",
+        "command": f"hammer {command}",
+        "output": output,
+        "error": error,
+        "returncode": returncode,
+    }
+
+
+def register_hammer_commands(mcp, _foreman_api, _get_context):
+    """Register hammer CLI command execution tools."""
+
+    @mcp.tool(
+        description="Execute a hammer CLI command with any arguments and return its output. Use "
+        "this ONLY when the user explicitly wants to execute a command on the MCP server's "
+        "environment. If the user just wants to know what hammer command to run, suggest it in "
+        "your response without calling this tool. A leading 'hammer' is NOT required in the command.",
+        tags=("hammer", "cli", "command", "local"),
+        annotations={
+            "title": "Execute Hammer CLI Command",
+            "readOnlyHint": False,
+            "destructiveHint": True,  # Hammer can be destructive
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def execute_hammer(command: str) -> ToolResult:
+        process = await asyncio.create_subprocess_exec(
+            "hammer",
+            *command.split(),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdout, stderr = await process.communicate()
+
+        # Decode output
+        stdout_text = stdout.decode("utf-8") if stdout else ""
+        stderr_text = stderr.decode("utf-8") if stderr else ""
+
+        if process.returncode == 0:
+            return build_tool_result(
+                build_success_structured_content(
+                    command, stdout_text, process.returncode
+                )
+            )
+        else:
+            return build_tool_result(
+                build_failure_structured_content(
+                    command, stdout_text, stderr_text, process.returncode
+                )
+            )

--- a/src/foreman_mcp_server/utils/hammer_utils.py
+++ b/src/foreman_mcp_server/utils/hammer_utils.py
@@ -1,0 +1,115 @@
+"""Shared utilities for Hammer CLI integration."""
+
+import asyncio
+import os
+import shlex
+
+
+# Command builders - return hammer commands without 'hammer' prefix
+def organization_list_command() -> str:
+    """Build hammer command for listing organizations."""
+    return "organization list"
+
+
+def organization_info_command(name: str) -> str:
+    """
+    Build hammer command for getting organization info.
+
+    Args:
+        name: Organization name
+    """
+    return f'organization info --name "{name}"'
+
+
+def get_user_credentials(get_context, foreman_api=None):
+    """
+    Extract user credentials from MCP context.
+
+    In streamable-http mode: Extracts credentials from request headers
+    In stdio mode: Returns None (uses ~/.hammer/cli_config.yml)
+
+    Args:
+        get_context: FastMCP context getter function
+        foreman_api: Optional ForemanApi instance to get URL from
+
+    Returns:
+        tuple: (username, password, foreman_url) or (None, None, None)
+    """
+    try:
+        ctx = get_context()
+        if ctx.request_context.request:
+            # Streamable-HTTP mode: get credentials from headers
+            username = ctx.request_context.request.headers.get("foreman_username")
+            password = ctx.request_context.request.headers.get("foreman_token")
+
+            # Get foreman_url from the foreman_api instance
+            foreman_url = None
+            if foreman_api:
+                foreman_url = foreman_api.uri
+            else:
+                # Try to get from middleware
+                from .utils import get_foreman_api
+
+                try:
+                    api_instance = get_foreman_api(get_context)
+                    if api_instance:
+                        foreman_url = api_instance.uri
+                except Exception:
+                    pass
+
+            return (username, password, foreman_url)
+    except Exception:
+        pass
+
+    # Stdio mode or no context: return None to use default config
+    return (None, None, None)
+
+
+async def execute_hammer_command(
+    command: str, username: str = None, password: str = None, foreman_url: str = None
+):
+    """
+    Execute a hammer CLI command with credentials.
+
+    Args:
+        command: The hammer command to execute (without 'hammer' prefix)
+        username: Foreman username (optional)
+        password: Foreman password (optional)
+        foreman_url: Foreman URL (optional)
+
+    Returns:
+        tuple: (success: bool, output: str, error: str = None, returncode: int)
+        - On success: (True, stdout_text, returncode)
+        - On failure: (False, stdout_text, stderr_text, returncode)
+    """
+    # Build environment with user-specific credentials
+    env = os.environ.copy()
+
+    # Set credentials via environment variables if provided
+    if username:
+        env["FOREMAN_USERNAME"] = username
+    if password:
+        env["FOREMAN_PASSWORD"] = password
+    if foreman_url:
+        env["FOREMAN_URL"] = foreman_url
+
+    # Execute hammer command with stdin redirected to /dev/null
+    # This prevents interactive password prompts
+    process = await asyncio.create_subprocess_exec(
+        "hammer",
+        *shlex.split(command),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.DEVNULL,  # Prevent interactive prompts
+        env=env,
+    )
+    stdout, stderr = await process.communicate()
+
+    # Decode output
+    stdout_text = stdout.decode("utf-8") if stdout else ""
+    stderr_text = stderr.decode("utf-8") if stderr else ""
+
+    if process.returncode == 0:
+        return (True, stdout_text, process.returncode)
+    else:
+        return (False, stdout_text, stderr_text, process.returncode)

--- a/tests/test_hammer_organization.py
+++ b/tests/test_hammer_organization.py
@@ -1,0 +1,36 @@
+from foreman_mcp_server.utils.hammer_utils import (
+    organization_info_command,
+    organization_list_command,
+)
+
+
+class TestHammerOrganizationCommands:
+    def test_organization_list_command(self):
+        """Test organization list command builder returns correct command."""
+        command = organization_list_command()
+        expected = "organization list"
+        assert command == expected
+
+    def test_organization_info_command(self):
+        """Test organization info command builder with simple name."""
+        command = organization_info_command("Default Organization")
+        expected = 'organization info --name "Default Organization"'
+        assert command == expected
+
+    def test_organization_info_command_with_simple_name(self):
+        """Test organization info command builder with single word name."""
+        command = organization_info_command("TestOrg")
+        expected = 'organization info --name "TestOrg"'
+        assert command == expected
+
+    def test_organization_info_command_with_spaces(self):
+        """Test organization info command builder handles names with spaces."""
+        command = organization_info_command("My Test Organization")
+        expected = 'organization info --name "My Test Organization"'
+        assert command == expected
+
+    def test_organization_info_command_with_special_chars(self):
+        """Test organization info command builder with special characters."""
+        command = organization_info_command("Org-123_Test")
+        expected = 'organization info --name "Org-123_Test"'
+        assert command == expected

--- a/tests/tools/test_call_hammer_commands.py
+++ b/tests/tools/test_call_hammer_commands.py
@@ -1,0 +1,148 @@
+from foreman_mcp_server.tools.call_hammer_commands import (
+    build_failure_structured_content,
+    build_success_structured_content,
+)
+from foreman_mcp_server.utils.content_utils import derive_legacy_content
+
+
+class TestCallHammerCommands:
+    def test_build_success_content(self):
+        command = "host list"
+        output = "host1.example.com\nhost2.example.com\n"
+        returncode = 0
+        expected = {
+            "message": f"Hammer command executed successfully: hammer {command}",
+            "command": f"hammer {command}",
+            "output": output,
+            "returncode": returncode,
+        }
+        structured = build_success_structured_content(command, output, returncode)
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == """# Message
+Hammer command executed successfully: hammer host list
+
+# Command
+hammer host list
+
+# Output
+host1.example.com
+host2.example.com
+
+
+# Returncode
+0
+"""
+        )
+
+    def test_build_failure_content(self):
+        command = "host delete --id 999"
+        output = ""
+        error = "Error: Host not found\n"
+        returncode = 1
+        expected = {
+            "message": f"Hammer command failed: hammer {command}",
+            "command": f"hammer {command}",
+            "output": output,
+            "error": error,
+            "returncode": returncode,
+        }
+
+        structured = build_failure_structured_content(
+            command, output, error, returncode
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == """# Message
+Hammer command failed: hammer host delete --id 999
+
+# Command
+hammer host delete --id 999
+
+# Output
+
+
+# Error
+Error: Host not found
+
+
+# Returncode
+1
+"""
+        )
+
+    def test_build_failure_content_with_output_and_error(self):
+        command = "host create --name test"
+        output = "Creating host...\n"
+        error = "Error: Missing required parameter --organization-id\n"
+        returncode = 65
+        expected = {
+            "message": f"Hammer command failed: hammer {command}",
+            "command": f"hammer {command}",
+            "output": output,
+            "error": error,
+            "returncode": returncode,
+        }
+
+        structured = build_failure_structured_content(
+            command, output, error, returncode
+        )
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == """# Message
+Hammer command failed: hammer host create --name test
+
+# Command
+hammer host create --name test
+
+# Output
+Creating host...
+
+
+# Error
+Error: Missing required parameter --organization-id
+
+
+# Returncode
+65
+"""
+        )
+
+    def test_build_success_content_with_empty_output(self):
+        command = "organization delete --id 1"
+        output = ""
+        returncode = 0
+        expected = {
+            "message": f"Hammer command executed successfully: hammer {command}",
+            "command": f"hammer {command}",
+            "output": output,
+            "returncode": returncode,
+        }
+        structured = build_success_structured_content(command, output, returncode)
+        assert structured == expected
+
+        content = derive_legacy_content(structured)
+        assert (
+            content
+            == """# Message
+Hammer command executed successfully: hammer organization delete --id 1
+
+# Command
+hammer organization delete --id 1
+
+# Output
+
+
+# Returncode
+0
+"""
+        )


### PR DESCRIPTION
This PR adds support for Hammer CLI commands with proper credential handling and organization-related resources. This PR requires https://github.com/theforeman/foreman-mcp-server/pull/29 as a base.

Hammer CLI commands like organization list and organization info require Foreman APIs to run. I implemented credential extraction from MCP request headers and pass them to hammer via environment variables.

The code follows a generate/execute pattern for organization commands. Generate resources return hammer command strings without executing them, while execute resources run the commands and return output. Both organization list and organization info are implemented with this pattern. Following the pattern from [#31](https://github.com/theforeman/foreman-mcp-server/pull/31), the implementation uses names only (via --name flag) instead of supporting multiple identifier types.

The implementation uses command builder helper functions in hammer_utils.py to centralize command construction logic, making it maintainable and reusable. 