### PR TITLE
Update ubi9 container image to 9.6-1762316373

### DIFF
--- a/Containerfile.ubi9
+++ b/Containerfile.ubi9
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-312-minimal:9.6-1760522101
+FROM registry.access.redhat.com/ubi9/python-312-minimal:9.6-1762316373
 
 USER 0
 


### PR DESCRIPTION
Using digest instead of tag, for some reason the tag is not working correctly