### PR TITLE
refactor(renovate): separate dependency updates into distinct PRs

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,11 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
+  "constraints": {
+    "python": "==3.12"
+  },
   "packageRules": [
     {
-      "matchPackagePatterns": ["*"],
-      "groupName": "all dependencies",
-      "groupSlug": "all"
+      "description": "Group all Python dependencies from pyproject.toml",
+      "matchManagers": ["pep621", "pip_requirements", "pip-compile"],
+      "matchFileNames": ["pyproject.toml", "requirements*.txt", "uv.lock"],
+      "groupName": "python dependencies",
+      "groupSlug": "python-deps"
+    },
+    {
+      "description": "Containerfile.ubi9 updates in separate PR",
+      "matchFileNames": ["Containerfile.ubi9"],
+      "groupName": "containerfile-ubi9",
+      "groupSlug": "containerfile-ubi9"
+    },
+    {
+      "description": "Tekton pipeline updates in separate PR",
+      "matchFileNames": [".tekton/**"],
+      "groupName": "tekton pipelines",
+      "groupSlug": "tekton"
     }
-  ]
+  ],
+  "separateMajorMinor": true,
+  "separateMinorPatch": false
 }


### PR DESCRIPTION
Configure Renovate to group updates by type instead of bundling everything into a single PR (like PR #65):

- Python dependencies (pyproject.toml, requirements*.txt, uv.lock) grouped into one PR
- Containerfile.ubi9 updates in separate PR
- Tekton pipeline updates (.tekton/**) in separate PR
- Pin Python version to 3.12 via constraints