### PR TITLE
Register new tools and prompts for remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,58 @@ claude-desktop
 
  - Click `+` button > Add from foreman: > Select any of Prompts and Resources from the server
  - Click Configuration button to select Tools from the server
+
+# Remote Execution Features
+
+The MCP server can trigger remote execution jobs on Foreman hosts. This functionality is **opt-in** and disabled by default for security reasons.
+
+## Enabling Remote Execution
+
+To enable remote execution, you must explicitly specify which remote execution features are allowed using the `--allowed-rex-features` option or the `FOREMAN_ALLOWED_REX_FEATURES` environment variable:
+
+```shell
+uv run foreman-mcp-server \
+  --foreman-url https://foreman.example.com \
+  --foreman-username $FOREMAN_USERNAME \
+  --foreman-password $FOREMAN_PASSWORD \
+  --allowed-rex-features "katello_errata_install,katello_package_install"
+```
+
+Or using the environment variable:
+
+```shell
+export FOREMAN_ALLOWED_REX_FEATURES="katello_errata_install,katello_package_install"
+uv run foreman-mcp-server ...
+```
+
+## How It Works
+
+1. **Allowlist-based security**: Only remote execution features explicitly listed in `--allowed-rex-features` can be triggered. Any attempt to use a feature not on the list will be rejected.
+
+2. **Available features resource**: When allowed features are configured, a resource becomes available at `foreman://remote_execution/allowed_features`. This resource returns information about each allowed feature, including:
+   - Feature label, ID, name, and description
+   - Associated job template ID and name
+   - Any errors (e.g., if the feature doesn't exist in Foreman)
+
+3. **Trigger tool**: The `trigger_remote_execution_job` tool is only enabled when at least one feature is allowed. To use it, the AI agent should:
+   1. Read the "Allowed Remote Execution Features" resource to see available features
+   2. Pick the appropriate feature for the task
+   3. Use `call_foreman_api_get` to read the feature's job template (`resource: "job_templates"`, `action: "show"`) to see what inputs it accepts
+   4. Call `trigger_remote_execution_job` with the feature label, search query, and appropriate inputs
+
+## Common Remote Execution Features
+
+Here are some commonly used remote execution feature labels:
+
+| Feature Label | Description |
+|---------------|-------------|
+| `katello_errata_install` | Install errata on hosts |
+| `katello_package_install` | Install packages on hosts |
+| `katello_package_update` | Update packages on hosts |
+| `katello_package_remove` | Remove packages from hosts |
+| `katello_host_tracer_resolve` | Resolve Tracer-detected services |
+
+To find all available features in your Foreman instance, you can use the API:
+```shell
+curl -u $USER:$PASSWORD https://foreman.example.com/api/remote_execution_features
+```

--- a/src/foreman_mcp_server/prompts/__init__.py
+++ b/src/foreman_mcp_server/prompts/__init__.py
@@ -1,3 +1,4 @@
+from .errata import register_errata_prompts
 from .reporting import register_reporting_prompts
 from .template_writing import register_template_writing_prompts
 
@@ -6,3 +7,4 @@ def register_prompts(mcp):
     """Register all reporting related prompts with the MCP server."""
     register_reporting_prompts(mcp)
     register_template_writing_prompts(mcp)
+    register_errata_prompts(mcp)

--- a/src/foreman_mcp_server/prompts/errata.py
+++ b/src/foreman_mcp_server/prompts/errata.py
@@ -1,0 +1,66 @@
+from pydantic import Field
+
+
+def register_errata_prompts(mcp, _foreman_api, _get_context):
+    @mcp.prompt(
+        name="Apply Errata to Hosts",
+        description="A prompt for applying a specific errata to applicable hosts in Foreman using remote execution.",
+    )
+    async def apply_errata_prompt(
+        errata_id: str = Field(description="The errata identifier (e.g., RHSA-2025:1234)"),
+    ) -> str:
+        prompt = f"""Help me apply the errata '{errata_id}' to hosts on my Foreman instance.
+
+Follow these steps:
+
+1. **Find applicable hosts**: Use the call_foreman_api_get tool to search for hosts where this errata can be installed:
+   - Resource: "hosts"
+   - Action: "index"
+   - Params: {{"search": "installable_errata = {errata_id}"}}
+
+   If no hosts are found, inform me and stop.
+
+2. **Present hosts and ask for confirmation**:
+   - List all the hosts found (show hostname and any relevant details like OS, environment, or host group)
+   - Ask me if I want to:
+     a) Apply the errata to ALL listed hosts
+     b) Apply to a SUBSET of hosts (ask me to specify which ones or provide a search query)
+     c) Cancel the operation
+
+   **IMPORTANT**: Do NOT proceed to trigger the job until I explicitly confirm which hosts to target.
+
+3. **Find the appropriate job template**: Once I confirm the target hosts, use call_foreman_api_get to list available job templates:
+   - Resource: "job_templates"
+   - Action: "index"
+   - Params: {{"search": "name ~ errata"}}
+
+   Look for a template that applies or installs errata (common names include "Install Errata - Katello Script Default" or similar).
+
+4. **Trigger the remote execution job**: Use the trigger_remote_execution_job tool with:
+   - job_template_id: The ID of the errata installation template
+   - search_query: Use the search query based on my selection:
+     - If ALL hosts: "installable_errata = {errata_id}"
+     - If SUBSET: combine with my specified criteria (e.g., "installable_errata = {errata_id} AND name ~ myhost")
+   - inputs: {{"errata": "{errata_id}"}} (adjust based on template requirements)
+   - description: "Apply errata {errata_id}"
+
+5. **Wait for completion**: Use the poll_task tool with the task_id returned from the job invocation. Use a reasonable timeout based on the number of hosts.
+
+6. **Check results**: After the task completes, use call_foreman_api_get to get job details:
+   - Resource: "job_invocations"
+   - Action: "show"
+   - Params: {{"id": <job_invocation_id>}}
+
+7. **Report summary**: Provide me with:
+   - Number of hosts targeted
+   - Number of successful/failed hosts
+   - Overall job status
+
+8. **Investigate failures** (if any): If hosts failed, use call_foreman_api_get to get host-specific output:
+   - Resource: "job_invocations"
+   - Action: "outputs"
+   - Params: {{"id": <job_invocation_id>, "host_status": "failed"}}
+
+   Summarize what went wrong and suggest remediation steps.
+"""
+        return prompt

--- a/src/foreman_mcp_server/prompts/errata.py
+++ b/src/foreman_mcp_server/prompts/errata.py
@@ -1,13 +1,15 @@
 from pydantic import Field
 
 
-def register_errata_prompts(mcp, _foreman_api, _get_context):
+def register_errata_prompts(mcp):
     @mcp.prompt(
         name="Apply Errata to Hosts",
         description="A prompt for applying a specific errata to applicable hosts in Foreman using remote execution.",
     )
     async def apply_errata_prompt(
-        errata_id: str = Field(description="The errata identifier (e.g., RHSA-2025:1234)"),
+        errata_id: str = Field(
+            description="The errata identifier (e.g., RHSA-2025:1234)"
+        ),
     ) -> str:
         prompt = f"""Help me apply the errata '{errata_id}' to hosts on my Foreman instance.
 

--- a/src/foreman_mcp_server/prompts/errata.py
+++ b/src/foreman_mcp_server/prompts/errata.py
@@ -29,11 +29,10 @@ Follow these steps:
 
    **IMPORTANT**: Do NOT proceed to trigger the job until I explicitly confirm which hosts to target.
 
-3. **Find the appropriate remote execution feature**: Once I confirm the target hosts, use call_foreman_api_get to list remote execution features:
-   - Resource: "remote_execution_features"
-   - Action: "index"
+3. **Find the appropriate remote execution feature**: Once I confirm the target hosts, read the allowed remote execution features resource:
+   - URI: "foreman://remote_execution/allowed_features"
 
-   Look for a feature related to errata installation (e.g., "katello_errata_install").
+   Look for a feature related to errata installation (e.g., "katello_errata_install"). This resource provides the allowed features along with their job template information.
 
 4. **Get template inputs**: Use call_foreman_api_get to read the feature's associated job template to see what inputs it accepts:
    - Resource: "job_templates"

--- a/src/foreman_mcp_server/prompts/errata.py
+++ b/src/foreman_mcp_server/prompts/errata.py
@@ -29,34 +29,38 @@ Follow these steps:
 
    **IMPORTANT**: Do NOT proceed to trigger the job until I explicitly confirm which hosts to target.
 
-3. **Find the appropriate job template**: Once I confirm the target hosts, use call_foreman_api_get to list available job templates:
-   - Resource: "job_templates"
+3. **Find the appropriate remote execution feature**: Once I confirm the target hosts, use call_foreman_api_get to list remote execution features:
+   - Resource: "remote_execution_features"
    - Action: "index"
-   - Params: {{"search": "name ~ errata"}}
 
-   Look for a template that applies or installs errata (common names include "Install Errata - Katello Script Default" or similar).
+   Look for a feature related to errata installation (e.g., "katello_errata_install").
 
-4. **Trigger the remote execution job**: Use the trigger_remote_execution_job tool with:
-   - job_template_id: The ID of the errata installation template
+4. **Get template inputs**: Use call_foreman_api_get to read the feature's associated job template to see what inputs it accepts:
+   - Resource: "job_templates"
+   - Action: "show"
+   - Params: {{"id": <job_template_id from the feature>}}
+
+5. **Trigger the remote execution job**: Use the trigger_remote_execution_job tool with:
+   - feature: The remote execution feature label (e.g., "katello_errata_install")
    - search_query: Use the search query based on my selection:
      - If ALL hosts: "installable_errata = {errata_id}"
      - If SUBSET: combine with my specified criteria (e.g., "installable_errata = {errata_id} AND name ~ myhost")
    - inputs: {{"errata": "{errata_id}"}} (adjust based on template requirements)
    - description: "Apply errata {errata_id}"
 
-5. **Wait for completion**: Use the poll_task tool with the task_id returned from the job invocation. Use a reasonable timeout based on the number of hosts.
+6. **Wait for completion**: Use the poll_task tool with the task_id returned from the job invocation. Use a reasonable timeout based on the number of hosts.
 
-6. **Check results**: After the task completes, use call_foreman_api_get to get job details:
+7. **Check results**: After the task completes, use call_foreman_api_get to get job details:
    - Resource: "job_invocations"
    - Action: "show"
    - Params: {{"id": <job_invocation_id>}}
 
-7. **Report summary**: Provide me with:
+8. **Report summary**: Provide me with:
    - Number of hosts targeted
    - Number of successful/failed hosts
    - Overall job status
 
-8. **Investigate failures** (if any): If hosts failed, use call_foreman_api_get to get host-specific output:
+9. **Investigate failures** (if any): If hosts failed, use call_foreman_api_get to get host-specific output:
    - Resource: "job_invocations"
    - Action: "outputs"
    - Params: {{"id": <job_invocation_id>, "host_status": "failed"}}

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -11,15 +11,11 @@ from .remote_execution_features import register_remote_execution_features
 # TODO: Maybe local logs can be a resource?
 
 
-def register_resources(
-    mcp, allowed_rex_features: Sequence[str] = ()
-):
+def register_resources(mcp, allowed_rex_features: Sequence[str] = ()):
     """Register all Foreman resources with the MCP server."""
     register_foreman_api_resources(mcp)
     register_foreman_api_resource_docs(mcp)
     register_foreman_dsl_sections(mcp)
     register_foreman_dsl_docs(mcp)
     register_foreman_template_resources(mcp)
-    register_remote_execution_features(
-        mcp, allowed_rex_features
-    )
+    register_remote_execution_features(mcp, allowed_rex_features)

--- a/src/foreman_mcp_server/resources/__init__.py
+++ b/src/foreman_mcp_server/resources/__init__.py
@@ -1,17 +1,25 @@
+from collections.abc import Sequence
+
 from .foreman_api_resource_docs import register_foreman_api_resource_docs
 from .foreman_api_resources import register_foreman_api_resources
 from .foreman_dsl_docs import register_foreman_dsl_docs
 from .foreman_dsl_sections import register_foreman_dsl_sections
 from .foreman_template_resources import register_foreman_template_resources
+from .remote_execution_features import register_remote_execution_features
 
 # TODO: For some resources consider refactoring: fetch_resource tool, search_resource tool.
 # TODO: Maybe local logs can be a resource?
 
 
-def register_resources(mcp):
+def register_resources(
+    mcp, allowed_rex_features: Sequence[str] = ()
+):
     """Register all Foreman resources with the MCP server."""
     register_foreman_api_resources(mcp)
     register_foreman_api_resource_docs(mcp)
     register_foreman_dsl_sections(mcp)
     register_foreman_dsl_docs(mcp)
     register_foreman_template_resources(mcp)
+    register_remote_execution_features(
+        mcp, allowed_rex_features
+    )

--- a/src/foreman_mcp_server/resources/remote_execution_features.py
+++ b/src/foreman_mcp_server/resources/remote_execution_features.py
@@ -3,12 +3,12 @@
 import json
 from collections.abc import Sequence
 
+from fastmcp import Context
+
 from foreman_mcp_server.utils.utils import get_foreman_api
 
 
-def register_remote_execution_features(
-    mcp, foreman_api, get_context, allowed_rex_features: Sequence[str] = ()
-):
+def register_remote_execution_features(mcp, allowed_rex_features: Sequence[str] = ()):
     @mcp.resource(
         name="Allowed Remote Execution Features",
         description=(
@@ -21,12 +21,12 @@ def register_remote_execution_features(
         mime_type="application/json",
         enabled=any(allowed_rex_features),
     )
-    async def allowed_remote_execution_features_resource() -> str:
+    async def allowed_remote_execution_features_resource(ctx: Context) -> str:
         if not any(allowed_rex_features):
             return json.dumps({"features": [], "allowed_labels": []}, indent=2)
 
         try:
-            api = foreman_api or get_foreman_api(get_context)
+            api = get_foreman_api(ctx)
 
             # Fetch all remote execution features from Foreman
             all_features = api.call(

--- a/src/foreman_mcp_server/resources/remote_execution_features.py
+++ b/src/foreman_mcp_server/resources/remote_execution_features.py
@@ -1,0 +1,119 @@
+"""Resource for listing allowed remote execution features."""
+
+import json
+from collections.abc import Sequence
+
+from foreman_mcp_server.utils.utils import get_foreman_api
+
+
+def register_remote_execution_features(
+    mcp, foreman_api, get_context, allowed_rex_features: Sequence[str] = ()
+):
+    @mcp.resource(
+        name="Allowed Remote Execution Features",
+        description=(
+            "Returns the list of allowed remote execution features. "
+            "Only features configured in the server's allowed-rex-features "
+            "list are included. Use the job_templates show API to get "
+            "template inputs for a specific template."
+        ),
+        uri="foreman://remote_execution/allowed_features",
+        mime_type="application/json",
+    )
+    async def allowed_remote_execution_features_resource() -> str:
+        if not any(allowed_rex_features):
+            return json.dumps({"features": [], "allowed_labels": []}, indent=2)
+
+        try:
+            api = foreman_api or get_foreman_api(get_context)
+
+            # Fetch all remote execution features from Foreman
+            all_features = api.call(
+                "remote_execution_features", "index", {"per_page": "all"}
+            ).get("results", [])
+
+            # Build lookup by label
+            features_by_label = {f.get("label"): f for f in all_features}
+
+            # Fetch all job templates for allowed features in one request
+            labels_list = ", ".join(allowed_rex_features)
+            search_query = f"feature.label ^ ({labels_list})"
+            templates = api.call(
+                "job_templates",
+                "index",
+                {"search": search_query, "per_page": len(allowed_rex_features)},
+            ).get("results", [])
+
+            # Build result for each allowed label
+            result_features = []
+            for label in allowed_rex_features:
+                feature = features_by_label.get(label)
+
+                if not feature:
+                    # Feature label not found in Foreman
+                    result_features.append(
+                        _build_feature_entry(
+                            label=label, error="Feature not found in Foreman"
+                        )
+                    )
+                    continue
+
+                template_id = feature.get("job_template_id")
+                template = next((t for t in templates if t["id"] == template_id), None)
+
+                error = None
+                template_name = None
+
+                if not template_id:
+                    error = "Feature has no associated job template"
+                elif not template:
+                    error = f"Job template (id={template_id}) not accessible"
+                else:
+                    template_name = template.get("name")
+
+                result_features.append(
+                    _build_feature_entry(
+                        label=label,
+                        feature=feature,
+                        template_id=template_id,
+                        template_name=template_name,
+                        error=error,
+                    )
+                )
+
+            return json.dumps(
+                {
+                    "features": result_features,
+                    "allowed_labels": list(allowed_rex_features),
+                },
+                indent=2,
+            )
+
+        except Exception as e:
+            return json.dumps(
+                {
+                    "features": [],
+                    "allowed_labels": list(allowed_rex_features),
+                    "error": f"Failed to fetch remote execution features: {e}",
+                },
+                indent=2,
+            )
+
+
+def _build_feature_entry(
+    label: str,
+    feature: dict | None = None,
+    template_id: int | None = None,
+    template_name: str | None = None,
+    error: str | None = None,
+) -> dict:
+    """Build a standardized feature entry for the response."""
+    return {
+        "label": label,
+        "id": feature.get("id") if feature else None,
+        "name": feature.get("name") if feature else None,
+        "description": feature.get("description") if feature else None,
+        "job_template_id": template_id,
+        "job_template_name": template_name,
+        "error": error,
+    }

--- a/src/foreman_mcp_server/resources/remote_execution_features.py
+++ b/src/foreman_mcp_server/resources/remote_execution_features.py
@@ -19,6 +19,7 @@ def register_remote_execution_features(
         ),
         uri="foreman://remote_execution/allowed_features",
         mime_type="application/json",
+        enabled=any(allowed_rex_features),
     )
     async def allowed_remote_execution_features_resource() -> str:
         if not any(allowed_rex_features):

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -105,7 +105,7 @@ def assert_server_mode(foreman_username: str, foreman_password: str, transport: 
 )
 @click.option(
     "--allowed-rex-features",
-    default="katello_errata_install,katello_errata_install_by_search",
+    default="",
     help="Comma-separated list of allowed remote execution feature labels.",
     envvar="FOREMAN_ALLOWED_REX_FEATURES",
     show_default=True,

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -25,6 +25,13 @@ def normalize_log_level(_ctx, _param, value):
     return value
 
 
+def parse_comma_separated_list(_ctx, _param, value):
+    """Parse a comma-separated string into a list of stripped values."""
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def assert_server_mode(foreman_username: str, foreman_password: str, transport: str):
     """Assert that the server is running in the correct mode."""
     if transport == "streamable-http":
@@ -96,6 +103,14 @@ def assert_server_mode(foreman_username: str, foreman_password: str, transport: 
     help="Path to CA certificate bundle file for SSL verification. If not specified, ./ca.pem will be used if it exists, otherwise system default CA bundle is used.",
     envvar="FOREMAN_CA_BUNDLE",
 )
+@click.option(
+    "--allowed-rex-features",
+    default="katello_errata_install,katello_errata_install_by_search",
+    help="Comma-separated list of allowed remote execution feature labels.",
+    envvar="FOREMAN_ALLOWED_REX_FEATURES",
+    show_default=True,
+    callback=parse_comma_separated_list,
+)
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -108,6 +123,7 @@ def main(
     transport: str,
     verify_ssl: bool,
     ca_bundle: str,
+    allowed_rex_features: list[str],
 ) -> int:
     """Run the Foreman MCP server."""
 
@@ -135,7 +151,7 @@ def main(
     if ca_bundle:
         verify_ssl = ca_bundle
 
-    register_tools(mcp)
+    register_tools(mcp, allowed_rex_features)
     register_resources(mcp)
     register_prompts(mcp)
 

--- a/src/foreman_mcp_server/server.py
+++ b/src/foreman_mcp_server/server.py
@@ -152,7 +152,7 @@ def main(
         verify_ssl = ca_bundle
 
     register_tools(mcp, allowed_rex_features)
-    register_resources(mcp)
+    register_resources(mcp, allowed_rex_features)
     register_prompts(mcp)
 
     foreman_api = None

--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -14,8 +14,6 @@ def register_tools(mcp, allowed_rex_features=None):
 
     Args:
         mcp: The FastMCP server instance
-        foreman_api: The Foreman API client (or None for HTTP transport)
-        get_context: Function to get the request context
         allowed_rex_features: Optional list of allowed remote execution feature labels
     """
 

--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -2,6 +2,7 @@ from .call_foreman_api import register_foreman_api_methods
 from .fetch_foreman_dsl_docs import register_fetch_foreman_dsl_docs
 from .get_foreman_api_resource_docs import register_get_foreman_api_resource_docs
 from .get_foreman_dsl_docs import register_get_foreman_dsl_docs
+from .remote_execution import register_remote_execution_tools
 from .tasks import register_task_tools
 
 # TODO: Maybe hammer can be a tool?
@@ -16,4 +17,5 @@ def register_tools(mcp):
     # TODO: Remove when Claude Desktop supports Resource with parameters
     register_get_foreman_api_resource_docs(mcp)
     register_get_foreman_dsl_docs(mcp)
+    register_remote_execution_tools(mcp)
     register_task_tools(mcp)

--- a/src/foreman_mcp_server/tools/__init__.py
+++ b/src/foreman_mcp_server/tools/__init__.py
@@ -9,13 +9,20 @@ from .tasks import register_task_tools
 # TODO: Maybe foreman-maintain can be a tool?
 
 
-def register_tools(mcp):
-    """Register all tools with the MCP server."""
+def register_tools(mcp, allowed_rex_features=None):
+    """Register all tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance
+        foreman_api: The Foreman API client (or None for HTTP transport)
+        get_context: Function to get the request context
+        allowed_rex_features: Optional list of allowed remote execution feature labels
+    """
 
     register_foreman_api_methods(mcp)
     register_fetch_foreman_dsl_docs(mcp)
     # TODO: Remove when Claude Desktop supports Resource with parameters
     register_get_foreman_api_resource_docs(mcp)
     register_get_foreman_dsl_docs(mcp)
-    register_remote_execution_tools(mcp)
+    register_remote_execution_tools(mcp, allowed_rex_features)
     register_task_tools(mcp)

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -17,6 +17,7 @@ def register_remote_execution_tools(
     get_context: Callable,
     allowed_rex_features: Sequence[str] = (),
 ) -> None:
+
     @mcp.tool(
         description="""Triggers a remote execution job on Foreman using a remote execution feature.
 
@@ -35,6 +36,7 @@ Returns the job invocation ID and task ID for polling.""",
             "idempotentHint": False,
             "openWorldHint": False,
         },
+        enabled=any(allowed_rex_features)
     )
     async def trigger_remote_execution_job(
         feature: str,

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -9,7 +9,15 @@ from ..utils.utils import get_foreman_api, mcp_info_headers
 
 def register_remote_execution_tools(mcp, foreman_api, get_context):
     @mcp.tool(
-        description="Triggers a remote execution job on Foreman. Returns the job invocation ID and task ID for polling.",
+        description="""Triggers a remote execution job on Foreman using a remote execution feature.
+
+Before using this tool, the agent should:
+1. Use call_foreman_api_get to list remote execution features (resource: "remote_execution_features", action: "index")
+2. Pick the appropriate feature for the task
+3. Use call_foreman_api_get to read the feature's associated job template (resource: "job_templates", action: "show", params: {"id": <job_template_id from feature>}) to see what inputs it accepts
+4. Call this tool with the feature label and appropriate inputs
+
+Returns the job invocation ID and task ID for polling.""",
         tags=("foreman", "api", "post", "remote-execution", "job"),
         annotations={
             "title": "Trigger Remote Execution Job",
@@ -20,16 +28,16 @@ def register_remote_execution_tools(mcp, foreman_api, get_context):
         },
     )
     async def trigger_remote_execution_job(
-        job_template_id: int,
+        feature: str,
         search_query: str,
         inputs: dict | None = None,
         description: str | None = None,
     ) -> ToolResult:
         """
-        Trigger a remote execution job on target hosts.
+        Trigger a remote execution job on target hosts using a remote execution feature.
 
         Args:
-            job_template_id: The ID of the job template to use
+            feature: The remote execution feature label (e.g., "katello_errata_install")
             search_query: Host search query (e.g., "installable_errata = RHSA-2025:1234")
             inputs: Optional dictionary of template inputs (varies by template)
             description: Optional description for the job invocation
@@ -40,7 +48,7 @@ def register_remote_execution_tools(mcp, foreman_api, get_context):
             # Build the job invocation payload
             job_invocation_params = {
                 "job_invocation": {
-                    "job_template_id": job_template_id,
+                    "feature": feature,
                     "targeting_type": "static_query",
                     "search_query": search_query,
                 }

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -1,5 +1,9 @@
 import json
+from collections.abc import Callable, Sequence
 
+import apypie
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 from requests.exceptions import HTTPError
 
@@ -7,7 +11,12 @@ from ..utils.content_utils import build_tool_result
 from ..utils.utils import get_foreman_api, mcp_info_headers
 
 
-def register_remote_execution_tools(mcp, foreman_api, get_context):
+def register_remote_execution_tools(
+    mcp: FastMCP,
+    foreman_api: apypie.ForemanApi | None,
+    get_context: Callable,
+    allowed_rex_features: Sequence[str] = (),
+) -> None:
     @mcp.tool(
         description="""Triggers a remote execution job on Foreman using a remote execution feature.
 
@@ -42,6 +51,13 @@ Returns the job invocation ID and task ID for polling.""",
             inputs: Optional dictionary of template inputs (varies by template)
             description: Optional description for the job invocation
         """
+        # Validate feature against allowlist
+        if feature not in allowed_rex_features:
+            raise ToolError(
+                f"Feature '{feature}' is not allowed. "
+                f"Allowed features: {', '.join(allowed_rex_features)}"
+            )
+
         try:
             api = foreman_api or get_foreman_api(get_context)
 

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -21,7 +21,7 @@ def register_remote_execution_tools(
         description="""Triggers a remote execution job on Foreman using a remote execution feature.
 
 Before using this tool, the agent should:
-1. Use call_foreman_api_get to list remote execution features (resource: "remote_execution_features", action: "index")
+1. Read the "Allowed Remote Execution Features" resource (foreman://remote_execution/allowed_features) to see available features
 2. Pick the appropriate feature for the task
 3. Use call_foreman_api_get to read the feature's associated job template (resource: "job_templates", action: "show", params: {"id": <job_template_id from feature>}) to see what inputs it accepts
 4. Call this tool with the feature label and appropriate inputs

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
+from pydantic import Field
 from requests.exceptions import HTTPError
 
 from ..utils.content_utils import build_tool_result
@@ -36,21 +37,25 @@ Returns the job invocation ID and task ID for polling.""",
         enabled=any(allowed_rex_features),
     )
     async def trigger_remote_execution_job(
-        feature: str,
-        search_query: str,
         ctx: Context,
-        inputs: dict | None = None,
-        description: str | None = None,
+        feature: str = Field(
+            ...,
+            description="The remote execution feature label (e.g., 'katello_errata_install')",
+        ),
+        search_query: str = Field(
+            ...,
+            description="Host search query (e.g., 'installable_errata = RHSA-2025:1234')",
+        ),
+        inputs: dict | None = Field(
+            default=None,
+            description="Optional dictionary of template inputs (varies by template)",
+        ),
+        description: str | None = Field(
+            default=None,
+            description="Optional description for the job invocation",
+        ),
     ) -> ToolResult:
-        """
-        Trigger a remote execution job on target hosts using a remote execution feature.
-
-        Args:
-            feature: The remote execution feature label (e.g., "katello_errata_install")
-            search_query: Host search query (e.g., "installable_errata = RHSA-2025:1234")
-            inputs: Optional dictionary of template inputs (varies by template)
-            description: Optional description for the job invocation
-        """
+        """Trigger a remote execution job on target hosts using a remote execution feature."""
         # Validate feature against allowlist
         if feature not in allowed_rex_features:
             raise ToolError(

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -1,0 +1,97 @@
+import json
+
+from fastmcp.tools.tool import ToolResult
+from requests.exceptions import HTTPError
+
+from ..utils.content_utils import build_tool_result
+from ..utils.utils import get_foreman_api, mcp_info_headers
+
+
+def register_remote_execution_tools(mcp, foreman_api, get_context):
+    @mcp.tool(
+        description="Triggers a remote execution job on Foreman. Returns the job invocation ID and task ID for polling.",
+        tags=("foreman", "api", "post", "remote-execution", "job"),
+        annotations={
+            "title": "Trigger Remote Execution Job",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def trigger_remote_execution_job(
+        job_template_id: int,
+        search_query: str,
+        inputs: dict | None = None,
+        description: str | None = None,
+    ) -> ToolResult:
+        """
+        Trigger a remote execution job on target hosts.
+
+        Args:
+            job_template_id: The ID of the job template to use
+            search_query: Host search query (e.g., "installable_errata = RHSA-2025:1234")
+            inputs: Optional dictionary of template inputs (varies by template)
+            description: Optional description for the job invocation
+        """
+        try:
+            api = foreman_api or get_foreman_api(get_context)
+
+            # Build the job invocation payload
+            job_invocation_params = {
+                "job_invocation": {
+                    "job_template_id": job_template_id,
+                    "targeting_type": "static_query",
+                    "search_query": search_query,
+                }
+            }
+
+            if inputs:
+                job_invocation_params["job_invocation"]["inputs"] = inputs
+
+            if description:
+                job_invocation_params["job_invocation"]["description"] = description
+
+            response = api.call(
+                "job_invocations",
+                "create",
+                job_invocation_params,
+                mcp_info_headers(get_context),
+            )
+
+            return format_job_invocation_success(response)
+        except Exception as e:
+            return format_job_invocation_failure(e)
+
+
+def format_job_invocation_success(response: dict) -> ToolResult:
+    """Format a successful job invocation response."""
+    structured_content = {
+        "message": "Remote execution job triggered successfully.",
+        "job_invocation_id": response.get("id"),
+        "task_id": response.get("task", {}).get("id") if response.get("task") else None,
+        "description": response.get("description"),
+        "status": response.get("status"),
+        "status_label": response.get("status_label"),
+        "targeting": {
+            "search_query": response.get("targeting", {}).get("search_query"),
+            "hosts_count": response.get("total_hosts_count"),
+        },
+    }
+    return build_tool_result(structured_content)
+
+
+def format_job_invocation_failure(exception: Exception) -> ToolResult:
+    """Format a failed job invocation response."""
+    structured_content = {
+        "message": "Failed to trigger remote execution job.",
+        "error": str(exception),
+    }
+    if isinstance(exception, HTTPError):
+        text = getattr(exception.response, "text", None)
+        if text:
+            try:
+                structured_content["response"] = json.loads(text)
+            except json.JSONDecodeError:
+                structured_content["response"] = text
+    return build_tool_result(structured_content)

--- a/src/foreman_mcp_server/tools/remote_execution.py
+++ b/src/foreman_mcp_server/tools/remote_execution.py
@@ -1,8 +1,7 @@
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 
-import apypie
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 from requests.exceptions import HTTPError
@@ -13,8 +12,6 @@ from ..utils.utils import get_foreman_api, mcp_info_headers
 
 def register_remote_execution_tools(
     mcp: FastMCP,
-    foreman_api: apypie.ForemanApi | None,
-    get_context: Callable,
     allowed_rex_features: Sequence[str] = (),
 ) -> None:
 
@@ -36,11 +33,12 @@ Returns the job invocation ID and task ID for polling.""",
             "idempotentHint": False,
             "openWorldHint": False,
         },
-        enabled=any(allowed_rex_features)
+        enabled=any(allowed_rex_features),
     )
     async def trigger_remote_execution_job(
         feature: str,
         search_query: str,
+        ctx: Context,
         inputs: dict | None = None,
         description: str | None = None,
     ) -> ToolResult:
@@ -61,7 +59,7 @@ Returns the job invocation ID and task ID for polling.""",
             )
 
         try:
-            api = foreman_api or get_foreman_api(get_context)
+            api = get_foreman_api(ctx)
 
             # Build the job invocation payload
             job_invocation_params = {
@@ -82,7 +80,7 @@ Returns the job invocation ID and task ID for polling.""",
                 "job_invocations",
                 "create",
                 job_invocation_params,
-                mcp_info_headers(get_context),
+                mcp_info_headers(ctx),
             )
 
             return format_job_invocation_success(response)

--- a/tests/resources/test_remote_execution_features.py
+++ b/tests/resources/test_remote_execution_features.py
@@ -1,0 +1,341 @@
+import asyncio
+import json
+from unittest.mock import Mock
+
+import pytest
+from fastmcp import FastMCP
+
+from foreman_mcp_server.resources.remote_execution_features import (
+    _build_feature_entry,
+    register_remote_execution_features,
+)
+
+
+class TestAllowedRemoteExecutionFeaturesResource:
+    """Test the allowed remote execution features resource."""
+
+    @pytest.fixture
+    def mcp(self):
+        return FastMCP(name="Test MCP Server")
+
+    @pytest.fixture
+    def mock_get_context(self):
+        return Mock()
+
+    def _get_resource_result(self, mcp):
+        """Helper to get the resource function and run it."""
+        resource = mcp._resource_manager._resources[
+            "foreman://remote_execution/allowed_features"
+        ]
+        return asyncio.run(resource.fn())
+
+    def test_empty_allowlist_returns_empty_features(self, mcp, mock_get_context):
+        """Test that an empty allowlist returns no features."""
+        register_remote_execution_features(mcp, None, mock_get_context, [])
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert result["features"] == []
+        assert result["allowed_labels"] == []
+
+    def test_happy_path_returns_features_with_template_info(
+        self, mcp, mock_get_context
+    ):
+        """Test that allowed features are returned with their template info."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: remote_execution_features index
+            {
+                "results": [
+                    {
+                        "id": 1,
+                        "label": "katello_errata_install",
+                        "name": "Katello Errata Install",
+                        "description": "Install errata via Katello",
+                        "job_template_id": 42,
+                    },
+                    {
+                        "id": 2,
+                        "label": "other_feature",
+                        "name": "Other Feature",
+                        "description": "Some other feature",
+                        "job_template_id": 99,
+                    },
+                ]
+            },
+            # Second call: job_templates index (batch)
+            {
+                "results": [
+                    {
+                        "id": 42,
+                        "name": "Install Errata - Katello Script Default",
+                    }
+                ]
+            },
+        ]
+
+        allowed_features = ["katello_errata_install"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert result["allowed_labels"] == ["katello_errata_install"]
+        assert len(result["features"]) == 1
+
+        feature = result["features"][0]
+        assert feature["label"] == "katello_errata_install"
+        assert feature["id"] == 1
+        assert feature["name"] == "Katello Errata Install"
+        assert feature["job_template_id"] == 42
+        assert feature["job_template_name"] == "Install Errata - Katello Script Default"
+        assert feature["error"] is None
+
+    def test_nonexistent_feature_label_reports_error(self, mcp, mock_get_context):
+        """Test that a feature label not found in Foreman is reported with error."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: remote_execution_features index - no matching feature
+            {"results": []},
+            # Second call: job_templates index (empty, no IDs to fetch)
+            {"results": []},
+        ]
+
+        allowed_features = ["nonexistent_feature"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert len(result["features"]) == 1
+        feature = result["features"][0]
+        assert feature["label"] == "nonexistent_feature"
+        assert feature["id"] is None
+        assert feature["error"] == "Feature not found in Foreman"
+
+    def test_feature_with_inaccessible_template(self, mcp, mock_get_context):
+        """Test that a feature whose template is not returned is reported with error."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: remote_execution_features index
+            {
+                "results": [
+                    {
+                        "id": 1,
+                        "label": "restricted_feature",
+                        "name": "Restricted Feature",
+                        "description": "Feature with restricted template",
+                        "job_template_id": 999,
+                    }
+                ]
+            },
+            # Second call: job_templates index - template not returned (permissions)
+            {"results": []},
+        ]
+
+        allowed_features = ["restricted_feature"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert len(result["features"]) == 1
+        feature = result["features"][0]
+        assert feature["label"] == "restricted_feature"
+        assert feature["id"] == 1
+        assert feature["job_template_id"] == 999
+        assert feature["error"] == "Job template (id=999) not accessible"
+
+    def test_feature_without_job_template(self, mcp, mock_get_context):
+        """Test that a feature with no associated job template is reported."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: remote_execution_features index
+            {
+                "results": [
+                    {
+                        "id": 1,
+                        "label": "no_template_feature",
+                        "name": "No Template Feature",
+                        "description": "Feature without template",
+                        "job_template_id": None,
+                    }
+                ]
+            },
+            # Second call: no job templates fetched (no IDs)
+            {"results": []},
+        ]
+
+        allowed_features = ["no_template_feature"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert len(result["features"]) == 1
+        feature = result["features"][0]
+        assert feature["label"] == "no_template_feature"
+        assert feature["error"] == "Feature has no associated job template"
+
+    def test_multiple_allowed_features_batch_fetches_templates(
+        self, mcp, mock_get_context
+    ):
+        """Test that multiple allowed features result in a single batch template fetch."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: remote_execution_features index
+            {
+                "results": [
+                    {
+                        "id": 1,
+                        "label": "feature_a",
+                        "name": "Feature A",
+                        "description": "First feature",
+                        "job_template_id": 10,
+                    },
+                    {
+                        "id": 2,
+                        "label": "feature_b",
+                        "name": "Feature B",
+                        "description": "Second feature",
+                        "job_template_id": 20,
+                    },
+                ]
+            },
+            # Second call: job_templates batch fetch
+            {
+                "results": [
+                    {
+                        "id": 10,
+                        "name": "Template A",
+                    },
+                    {
+                        "id": 20,
+                        "name": "Template B",
+                    },
+                ]
+            },
+        ]
+
+        allowed_features = ["feature_a", "feature_b"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert len(result["features"]) == 2
+        assert result["features"][0]["label"] == "feature_a"
+        assert result["features"][0]["job_template_name"] == "Template A"
+        assert result["features"][1]["label"] == "feature_b"
+        assert result["features"][1]["job_template_name"] == "Template B"
+
+        # Verify batch fetch - job_templates.index called with feature.label search
+        calls = mock_api.call.call_args_list
+        assert len(calls) == 2
+        assert calls[1][0][0] == "job_templates"
+        assert calls[1][0][1] == "index"
+        # Search should use feature.label with IN syntax
+        search_param = calls[1][0][2]["search"]
+        assert search_param == "feature.label ^ (feature_a, feature_b)"
+
+    def test_api_error_returns_error_message(self, mcp, mock_get_context):
+        """Test that an API error returns an error message in the response."""
+        mock_api = Mock()
+        mock_api.call.side_effect = Exception("Connection refused")
+
+        allowed_features = ["some_feature"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert result["features"] == []
+        assert result["allowed_labels"] == ["some_feature"]
+        assert "Connection refused" in result["error"]
+
+    def test_mixed_found_and_not_found_features(self, mcp, mock_get_context):
+        """Test a mix of existing and non-existing features."""
+        mock_api = Mock()
+        mock_api.call.side_effect = [
+            # First call: only one feature exists
+            {
+                "results": [
+                    {
+                        "id": 1,
+                        "label": "existing_feature",
+                        "name": "Existing Feature",
+                        "description": "This one exists",
+                        "job_template_id": 50,
+                    }
+                ]
+            },
+            # Second call: template fetch
+            {
+                "results": [
+                    {
+                        "id": 50,
+                        "name": "Existing Template",
+                    }
+                ]
+            },
+        ]
+
+        allowed_features = ["existing_feature", "missing_feature"]
+        register_remote_execution_features(
+            mcp, mock_api, mock_get_context, allowed_features
+        )
+
+        result = json.loads(self._get_resource_result(mcp))
+
+        assert len(result["features"]) == 2
+
+        existing = result["features"][0]
+        assert existing["label"] == "existing_feature"
+        assert existing["error"] is None
+
+        missing = result["features"][1]
+        assert missing["label"] == "missing_feature"
+        assert missing["error"] == "Feature not found in Foreman"
+
+
+class TestHelperFunctions:
+    """Test helper functions."""
+
+    def test_build_feature_entry_with_all_data(self):
+        feature = {
+            "id": 1,
+            "name": "Test Feature",
+            "description": "A test feature",
+        }
+        result = _build_feature_entry(
+            label="test_feature",
+            feature=feature,
+            template_id=42,
+            template_name="Test Template",
+            error=None,
+        )
+
+        assert result["label"] == "test_feature"
+        assert result["id"] == 1
+        assert result["name"] == "Test Feature"
+        assert result["description"] == "A test feature"
+        assert result["job_template_id"] == 42
+        assert result["job_template_name"] == "Test Template"
+        assert result["error"] is None
+
+    def test_build_feature_entry_with_error(self):
+        result = _build_feature_entry(
+            label="missing_feature", error="Feature not found in Foreman"
+        )
+
+        assert result["label"] == "missing_feature"
+        assert result["id"] is None
+        assert result["name"] is None
+        assert result["job_template_id"] is None
+        assert result["error"] == "Feature not found in Foreman"

--- a/tests/resources/test_remote_execution_features.py
+++ b/tests/resources/test_remote_execution_features.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import FastMCP
@@ -19,27 +19,28 @@ class TestAllowedRemoteExecutionFeaturesResource:
         return FastMCP(name="Test MCP Server")
 
     @pytest.fixture
-    def mock_get_context(self):
+    def mock_ctx(self):
         return Mock()
 
-    def _get_resource_result(self, mcp):
+    def _get_resource_result(self, mcp, ctx):
         """Helper to get the resource function and run it."""
         resource = mcp._resource_manager._resources[
             "foreman://remote_execution/allowed_features"
         ]
-        return asyncio.run(resource.fn())
+        return asyncio.run(resource.fn(ctx))
 
-    def test_empty_allowlist_returns_empty_features(self, mcp, mock_get_context):
+    def test_empty_allowlist_returns_empty_features(self, mcp, mock_ctx):
         """Test that an empty allowlist returns no features."""
-        register_remote_execution_features(mcp, None, mock_get_context, [])
+        register_remote_execution_features(mcp, [])
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert result["features"] == []
         assert result["allowed_labels"] == []
 
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
     def test_happy_path_returns_features_with_template_info(
-        self, mcp, mock_get_context
+        self, mock_get_foreman_api, mcp, mock_ctx
     ):
         """Test that allowed features are returned with their template info."""
         mock_api = Mock()
@@ -73,13 +74,12 @@ class TestAllowedRemoteExecutionFeaturesResource:
                 ]
             },
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["katello_errata_install"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert result["allowed_labels"] == ["katello_errata_install"]
         assert len(result["features"]) == 1
@@ -92,7 +92,10 @@ class TestAllowedRemoteExecutionFeaturesResource:
         assert feature["job_template_name"] == "Install Errata - Katello Script Default"
         assert feature["error"] is None
 
-    def test_nonexistent_feature_label_reports_error(self, mcp, mock_get_context):
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
+    def test_nonexistent_feature_label_reports_error(
+        self, mock_get_foreman_api, mcp, mock_ctx
+    ):
         """Test that a feature label not found in Foreman is reported with error."""
         mock_api = Mock()
         mock_api.call.side_effect = [
@@ -101,13 +104,12 @@ class TestAllowedRemoteExecutionFeaturesResource:
             # Second call: job_templates index (empty, no IDs to fetch)
             {"results": []},
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["nonexistent_feature"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert len(result["features"]) == 1
         feature = result["features"][0]
@@ -115,7 +117,10 @@ class TestAllowedRemoteExecutionFeaturesResource:
         assert feature["id"] is None
         assert feature["error"] == "Feature not found in Foreman"
 
-    def test_feature_with_inaccessible_template(self, mcp, mock_get_context):
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
+    def test_feature_with_inaccessible_template(
+        self, mock_get_foreman_api, mcp, mock_ctx
+    ):
         """Test that a feature whose template is not returned is reported with error."""
         mock_api = Mock()
         mock_api.call.side_effect = [
@@ -134,13 +139,12 @@ class TestAllowedRemoteExecutionFeaturesResource:
             # Second call: job_templates index - template not returned (permissions)
             {"results": []},
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["restricted_feature"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert len(result["features"]) == 1
         feature = result["features"][0]
@@ -149,7 +153,8 @@ class TestAllowedRemoteExecutionFeaturesResource:
         assert feature["job_template_id"] == 999
         assert feature["error"] == "Job template (id=999) not accessible"
 
-    def test_feature_without_job_template(self, mcp, mock_get_context):
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
+    def test_feature_without_job_template(self, mock_get_foreman_api, mcp, mock_ctx):
         """Test that a feature with no associated job template is reported."""
         mock_api = Mock()
         mock_api.call.side_effect = [
@@ -168,21 +173,21 @@ class TestAllowedRemoteExecutionFeaturesResource:
             # Second call: no job templates fetched (no IDs)
             {"results": []},
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["no_template_feature"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert len(result["features"]) == 1
         feature = result["features"][0]
         assert feature["label"] == "no_template_feature"
         assert feature["error"] == "Feature has no associated job template"
 
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
     def test_multiple_allowed_features_batch_fetches_templates(
-        self, mcp, mock_get_context
+        self, mock_get_foreman_api, mcp, mock_ctx
     ):
         """Test that multiple allowed features result in a single batch template fetch."""
         mock_api = Mock()
@@ -220,13 +225,12 @@ class TestAllowedRemoteExecutionFeaturesResource:
                 ]
             },
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["feature_a", "feature_b"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert len(result["features"]) == 2
         assert result["features"][0]["label"] == "feature_a"
@@ -243,23 +247,26 @@ class TestAllowedRemoteExecutionFeaturesResource:
         search_param = calls[1][0][2]["search"]
         assert search_param == "feature.label ^ (feature_a, feature_b)"
 
-    def test_api_error_returns_error_message(self, mcp, mock_get_context):
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
+    def test_api_error_returns_error_message(self, mock_get_foreman_api, mcp, mock_ctx):
         """Test that an API error returns an error message in the response."""
-        mock_api = Mock()
-        mock_api.call.side_effect = Exception("Connection refused")
-
-        allowed_features = ["some_feature"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
+        mock_get_foreman_api.return_value.call.side_effect = Exception(
+            "Connection refused"
         )
 
-        result = json.loads(self._get_resource_result(mcp))
+        allowed_features = ["some_feature"]
+        register_remote_execution_features(mcp, allowed_features)
+
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert result["features"] == []
         assert result["allowed_labels"] == ["some_feature"]
         assert "Connection refused" in result["error"]
 
-    def test_mixed_found_and_not_found_features(self, mcp, mock_get_context):
+    @patch("foreman_mcp_server.resources.remote_execution_features.get_foreman_api")
+    def test_mixed_found_and_not_found_features(
+        self, mock_get_foreman_api, mcp, mock_ctx
+    ):
         """Test a mix of existing and non-existing features."""
         mock_api = Mock()
         mock_api.call.side_effect = [
@@ -285,13 +292,12 @@ class TestAllowedRemoteExecutionFeaturesResource:
                 ]
             },
         ]
+        mock_get_foreman_api.return_value = mock_api
 
         allowed_features = ["existing_feature", "missing_feature"]
-        register_remote_execution_features(
-            mcp, mock_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_features(mcp, allowed_features)
 
-        result = json.loads(self._get_resource_result(mcp))
+        result = json.loads(self._get_resource_result(mcp, mock_ctx))
 
         assert len(result["features"]) == 2
 

--- a/tests/tools/test_remote_execution.py
+++ b/tests/tools/test_remote_execution.py
@@ -28,7 +28,10 @@ class TestTriggerRemoteExecutionJob:
 
         result = format_job_invocation_success(response)
 
-        assert result.structured_content["message"] == "Remote execution job triggered successfully."
+        assert (
+            result.structured_content["message"]
+            == "Remote execution job triggered successfully."
+        )
         assert result.structured_content["job_invocation_id"] == 123
         assert result.structured_content["task_id"] == "abc-123-def"
         assert result.structured_content["description"] == "Apply errata RHSA-2025:1234"
@@ -54,7 +57,10 @@ class TestTriggerRemoteExecutionJob:
 
         result = format_job_invocation_failure(error)
 
-        assert result.structured_content["message"] == "Failed to trigger remote execution job."
+        assert (
+            result.structured_content["message"]
+            == "Failed to trigger remote execution job."
+        )
         assert result.structured_content["error"] == "Connection refused"
 
     def test_format_job_invocation_failure_with_http_error(self):
@@ -65,9 +71,14 @@ class TestTriggerRemoteExecutionJob:
 
         result = format_job_invocation_failure(error)
 
-        assert result.structured_content["message"] == "Failed to trigger remote execution job."
+        assert (
+            result.structured_content["message"]
+            == "Failed to trigger remote execution job."
+        )
         assert "422 Unprocessable Entity" in result.structured_content["error"]
-        assert result.structured_content["response"] == {"error": "Job template not found"}
+        assert result.structured_content["response"] == {
+            "error": "Job template not found"
+        }
 
     def test_format_job_invocation_failure_with_http_error_html_response(self):
         error = HTTPError(
@@ -171,4 +182,3 @@ class TestRexFeatureAllowlist:
 
         tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
         assert tool.enabled is False
-

--- a/tests/tools/test_remote_execution.py
+++ b/tests/tools/test_remote_execution.py
@@ -171,21 +171,12 @@ class TestRexFeatureAllowlist:
         assert "katello_errata_install" in str(exc_info.value)
         mock_foreman_api.call.assert_not_called()
 
-    def test_empty_allowlist_blocks_all_features(
+    def test_empty_allowlist_prevents_tool_from_being_registered(
         self, mcp, mock_foreman_api, mock_get_context
     ):
-        """Test that an empty allowlist blocks all features."""
+        """Test that an empty allowlist prevents the tool from being registered at all."""
         register_remote_execution_tools(mcp, mock_foreman_api, mock_get_context, [])
 
-        tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
+        with pytest.raises(KeyError) as exc_info:
+            mcp._tool_manager._tools["trigger_remote_execution_job"]
 
-        with pytest.raises(ToolError) as exc_info:
-            asyncio.run(
-                tool.fn(
-                    feature="katello_errata_install",
-                    search_query="name ~ test",
-                )
-            )
-
-        assert "not allowed" in str(exc_info.value)
-        mock_foreman_api.call.assert_not_called()

--- a/tests/tools/test_remote_execution.py
+++ b/tests/tools/test_remote_execution.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import FastMCP
@@ -110,9 +110,14 @@ class TestRexFeatureAllowlist:
         return FastMCP(name="Test MCP Server")
 
     @pytest.fixture
-    def mock_foreman_api(self):
-        api = Mock()
-        api.call.return_value = {
+    def mock_ctx(self):
+        return Mock()
+
+    @patch("foreman_mcp_server.tools.remote_execution.get_foreman_api")
+    def test_allowed_feature_passes(self, mock_get_foreman_api, mcp, mock_ctx):
+        """Test that an allowed feature passes validation."""
+        mock_api = Mock()
+        mock_api.call.return_value = {
             "id": 123,
             "description": "Test job",
             "status": 0,
@@ -121,18 +126,10 @@ class TestRexFeatureAllowlist:
             "targeting": {"search_query": "name ~ test"},
             "total_hosts_count": 1,
         }
-        return api
+        mock_get_foreman_api.return_value = mock_api
 
-    @pytest.fixture
-    def mock_get_context(self):
-        return Mock()
-
-    def test_allowed_feature_passes(self, mcp, mock_foreman_api, mock_get_context):
-        """Test that an allowed feature passes validation."""
         allowed_features = ["katello_errata_install", "katello_package_install"]
-        register_remote_execution_tools(
-            mcp, mock_foreman_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_tools(mcp, allowed_features)
 
         # Get the registered tool function
         tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
@@ -141,20 +138,17 @@ class TestRexFeatureAllowlist:
             tool.fn(
                 feature="katello_errata_install",
                 search_query="name ~ test",
+                ctx=mock_ctx,
             )
         )
 
         assert result.structured_content["job_invocation_id"] == 123
-        mock_foreman_api.call.assert_called_once()
+        mock_api.call.assert_called_once()
 
-    def test_disallowed_feature_raises_error(
-        self, mcp, mock_foreman_api, mock_get_context
-    ):
+    def test_disallowed_feature_raises_error(self, mcp, mock_ctx):
         """Test that a disallowed feature raises ToolError."""
         allowed_features = ["katello_errata_install"]
-        register_remote_execution_tools(
-            mcp, mock_foreman_api, mock_get_context, allowed_features
-        )
+        register_remote_execution_tools(mcp, allowed_features)
 
         tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
 
@@ -163,20 +157,18 @@ class TestRexFeatureAllowlist:
                 tool.fn(
                     feature="run_arbitrary_script",
                     search_query="name ~ test",
+                    ctx=mock_ctx,
                 )
             )
 
         assert "not allowed" in str(exc_info.value)
         assert "run_arbitrary_script" in str(exc_info.value)
         assert "katello_errata_install" in str(exc_info.value)
-        mock_foreman_api.call.assert_not_called()
 
-    def test_empty_allowlist_prevents_tool_from_being_registered(
-        self, mcp, mock_foreman_api, mock_get_context
-    ):
-        """Test that an empty allowlist prevents the tool from being registered at all."""
-        register_remote_execution_tools(mcp, mock_foreman_api, mock_get_context, [])
+    def test_empty_allowlist_disables_tool(self, mcp):
+        """Test that an empty allowlist registers the tool as disabled."""
+        register_remote_execution_tools(mcp, [])
 
-        with pytest.raises(KeyError) as exc_info:
-            mcp._tool_manager._tools["trigger_remote_execution_job"]
+        tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
+        assert tool.enabled is False
 

--- a/tests/tools/test_remote_execution.py
+++ b/tests/tools/test_remote_execution.py
@@ -1,0 +1,97 @@
+from unittest.mock import Mock
+
+from requests.exceptions import HTTPError
+
+from foreman_mcp_server.tools.remote_execution import (
+    format_job_invocation_failure,
+    format_job_invocation_success,
+)
+from foreman_mcp_server.utils.content_utils import derive_legacy_content
+
+
+class TestTriggerRemoteExecutionJob:
+    def test_format_job_invocation_success(self):
+        response = {
+            "id": 123,
+            "description": "Apply errata RHSA-2025:1234",
+            "status": 0,
+            "status_label": "queued",
+            "task": {"id": "abc-123-def"},
+            "targeting": {"search_query": "installable_errata = RHSA-2025:1234"},
+            "total_hosts_count": 5,
+        }
+
+        result = format_job_invocation_success(response)
+
+        assert result.structured_content["message"] == "Remote execution job triggered successfully."
+        assert result.structured_content["job_invocation_id"] == 123
+        assert result.structured_content["task_id"] == "abc-123-def"
+        assert result.structured_content["description"] == "Apply errata RHSA-2025:1234"
+        assert result.structured_content["targeting"]["hosts_count"] == 5
+
+    def test_format_job_invocation_success_without_task(self):
+        response = {
+            "id": 123,
+            "description": "Test job",
+            "status": 0,
+            "status_label": "queued",
+            "task": None,
+            "targeting": {"search_query": "name ~ test"},
+            "total_hosts_count": 1,
+        }
+
+        result = format_job_invocation_success(response)
+
+        assert result.structured_content["task_id"] is None
+
+    def test_format_job_invocation_failure(self):
+        error = Exception("Connection refused")
+
+        result = format_job_invocation_failure(error)
+
+        assert result.structured_content["message"] == "Failed to trigger remote execution job."
+        assert result.structured_content["error"] == "Connection refused"
+
+    def test_format_job_invocation_failure_with_http_error(self):
+        error = HTTPError(
+            "422 Unprocessable Entity",
+            response=Mock(text='{"error": "Job template not found"}'),
+        )
+
+        result = format_job_invocation_failure(error)
+
+        assert result.structured_content["message"] == "Failed to trigger remote execution job."
+        assert "422 Unprocessable Entity" in result.structured_content["error"]
+        assert result.structured_content["response"] == {"error": "Job template not found"}
+
+    def test_format_job_invocation_failure_with_http_error_html_response(self):
+        error = HTTPError(
+            "500 Internal Server Error",
+            response=Mock(text="<html>Internal Error</html>"),
+        )
+
+        result = format_job_invocation_failure(error)
+
+        assert result.structured_content["response"] == "<html>Internal Error</html>"
+
+
+class TestLegacyContentDerivation:
+    """Test that structured content can be properly converted to legacy text format."""
+
+    def test_job_invocation_success_legacy_content(self):
+        response = {
+            "id": 123,
+            "task": {"id": "abc-123"},
+            "targeting": {"search_query": "name ~ test"},
+            "total_hosts_count": 2,
+            "status": 0,
+            "status_label": "queued",
+            "description": "Test job",
+        }
+
+        result = format_job_invocation_success(response)
+        content = derive_legacy_content(result.structured_content)
+
+        assert "Remote execution job triggered successfully" in content
+        assert "123" in content  # job_invocation_id
+        assert "abc-123" in content  # task_id

--- a/tests/tools/test_remote_execution.py
+++ b/tests/tools/test_remote_execution.py
@@ -1,10 +1,15 @@
+import asyncio
 from unittest.mock import Mock
 
+import pytest
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from requests.exceptions import HTTPError
 
 from foreman_mcp_server.tools.remote_execution import (
     format_job_invocation_failure,
     format_job_invocation_success,
+    register_remote_execution_tools,
 )
 from foreman_mcp_server.utils.content_utils import derive_legacy_content
 
@@ -95,3 +100,92 @@ class TestLegacyContentDerivation:
         assert "Remote execution job triggered successfully" in content
         assert "123" in content  # job_invocation_id
         assert "abc-123" in content  # task_id
+
+
+class TestRexFeatureAllowlist:
+    """Test remote execution feature allowlist functionality."""
+
+    @pytest.fixture
+    def mcp(self):
+        return FastMCP(name="Test MCP Server")
+
+    @pytest.fixture
+    def mock_foreman_api(self):
+        api = Mock()
+        api.call.return_value = {
+            "id": 123,
+            "description": "Test job",
+            "status": 0,
+            "status_label": "queued",
+            "task": {"id": "task-123"},
+            "targeting": {"search_query": "name ~ test"},
+            "total_hosts_count": 1,
+        }
+        return api
+
+    @pytest.fixture
+    def mock_get_context(self):
+        return Mock()
+
+    def test_allowed_feature_passes(self, mcp, mock_foreman_api, mock_get_context):
+        """Test that an allowed feature passes validation."""
+        allowed_features = ["katello_errata_install", "katello_package_install"]
+        register_remote_execution_tools(
+            mcp, mock_foreman_api, mock_get_context, allowed_features
+        )
+
+        # Get the registered tool function
+        tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
+
+        result = asyncio.run(
+            tool.fn(
+                feature="katello_errata_install",
+                search_query="name ~ test",
+            )
+        )
+
+        assert result.structured_content["job_invocation_id"] == 123
+        mock_foreman_api.call.assert_called_once()
+
+    def test_disallowed_feature_raises_error(
+        self, mcp, mock_foreman_api, mock_get_context
+    ):
+        """Test that a disallowed feature raises ToolError."""
+        allowed_features = ["katello_errata_install"]
+        register_remote_execution_tools(
+            mcp, mock_foreman_api, mock_get_context, allowed_features
+        )
+
+        tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
+
+        with pytest.raises(ToolError) as exc_info:
+            asyncio.run(
+                tool.fn(
+                    feature="run_arbitrary_script",
+                    search_query="name ~ test",
+                )
+            )
+
+        assert "not allowed" in str(exc_info.value)
+        assert "run_arbitrary_script" in str(exc_info.value)
+        assert "katello_errata_install" in str(exc_info.value)
+        mock_foreman_api.call.assert_not_called()
+
+    def test_empty_allowlist_blocks_all_features(
+        self, mcp, mock_foreman_api, mock_get_context
+    ):
+        """Test that an empty allowlist blocks all features."""
+        register_remote_execution_tools(mcp, mock_foreman_api, mock_get_context, [])
+
+        tool = mcp._tool_manager._tools["trigger_remote_execution_job"]
+
+        with pytest.raises(ToolError) as exc_info:
+            asyncio.run(
+                tool.fn(
+                    feature="katello_errata_install",
+                    search_query="name ~ test",
+                )
+            )
+
+        assert "not allowed" in str(exc_info.value)
+        mock_foreman_api.call.assert_not_called()


### PR DESCRIPTION
Very much just a POC, very much a product of letting opus4.5 run wild

Includes https://github.com/theforeman/foreman-mcp-server/pull/74

TODOs:
- [x] force the use through REX features (ie disallow direct job template use)
- [x] introduce a list of allowed features
  - the job running tool should reject features not on the list
  - the list should have a sane default
  - the list should be configurable through cli options
