### PR TITLE
Ignore ca.pem instead of katello-server-ca.crt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ wheels/
 
 .vscode
 
-katello-server-ca.crt
+ca.pem
 .mcp.json


### PR DESCRIPTION
Something we forgot to do during https://github.com/theforeman/foreman-mcp-server/blob/develop/src/foreman_mcp_server/server.py#L130