### PR TITLE
Change call_foreman_api_get 'params' type from dict to JSON string (rebased)

### DIFF
--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -52,7 +52,7 @@ def register_foreman_api_methods(mcp):
             "The 'params' argument must be a JSON string representing "
             "the request parameters, e.g. "
             '\'{"search": "name ~ test", "per_page": 20}\' or '
-            '\'{"id": 1}\'.'
+            "'{\"id\": 1}'."
         ),
         tags=("foreman", "api", "get", "resource", "remote"),
         annotations={

--- a/src/foreman_mcp_server/tools/call_foreman_api.py
+++ b/src/foreman_mcp_server/tools/call_foreman_api.py
@@ -14,10 +14,46 @@ from ..utils.utils import (
 )
 
 
+def _parse_params(params: str) -> dict:
+    """Parse a JSON string into a dict for Foreman API params.
+
+    Also normalises float values to int where appropriate,
+    since some MCP clients send integers as floats (e.g. 3.0 instead of 3).
+    """
+    try:
+        parsed = json.loads(params)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(
+            f"'params' must be a valid JSON string, got: {params!r}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"'params' must be a JSON object (dict), got {type(parsed).__name__}"
+        )
+    return _normalize_numeric_values(parsed)
+
+
+def _normalize_numeric_values(obj):
+    """Recursively convert float values that are whole numbers to int."""
+    if isinstance(obj, dict):
+        return {k: _normalize_numeric_values(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_numeric_values(item) for item in obj]
+    if isinstance(obj, float) and obj.is_integer():
+        return int(obj)
+    return obj
+
+
 # TODO: Probably split it into multiple tools (read-only, destructive, etc)
 def register_foreman_api_methods(mcp):
     @mcp.tool(
-        description="Calls GET action on Foreman API.",
+        description=(
+            "Calls GET action on Foreman API. "
+            "The 'params' argument must be a JSON string representing "
+            "the request parameters, e.g. "
+            '\'{"search": "name ~ test", "per_page": 20}\' or '
+            '\'{"id": 1}\'.'
+        ),
         tags=("foreman", "api", "get", "resource", "remote"),
         annotations={
             "title": "Call Foreman API GET Action",
@@ -30,10 +66,11 @@ def register_foreman_api_methods(mcp):
     async def call_foreman_api_get(
         resource: str,
         action: str,
-        params: dict,
+        params: str,
         ctx: Context,
     ) -> ToolResult:
         try:
+            parsed_params = _parse_params(params)
             api = get_foreman_api(ctx)
             await assert_resource(
                 resource,
@@ -42,10 +79,10 @@ def register_foreman_api_methods(mcp):
             )
             assert_http_method(
                 api,
-                {"name": action, "resource": resource, "params": params},
+                {"name": action, "resource": resource, "params": parsed_params},
                 "get",
             )
-            response = api.call(resource, action, params, mcp_info_headers(ctx))
+            response = api.call(resource, action, parsed_params, mcp_info_headers(ctx))
             return format_success_response(resource, action, response)
         except Exception as e:
             return format_failure_response(resource, action, e)

--- a/tests/tools/test_call_foreman_api.py
+++ b/tests/tools/test_call_foreman_api.py
@@ -1,12 +1,71 @@
 from unittest.mock import Mock
 
+import pytest
 from requests.exceptions import HTTPError
 
 from foreman_mcp_server.tools.call_foreman_api import (
+    _normalize_numeric_values,
+    _parse_params,
     build_failure_structured_content,
     build_success_structured_content,
 )
 from foreman_mcp_server.utils.content_utils import derive_legacy_content
+
+
+class TestParseParams:
+    def test_valid_json_object(self):
+        result = _parse_params('{"search": "name ~ test", "per_page": 20}')
+        assert result == {"search": "name ~ test", "per_page": 20}
+
+    def test_empty_json_object(self):
+        result = _parse_params("{}")
+        assert result == {}
+
+    def test_float_to_int_normalization(self):
+        result = _parse_params('{"id": 3.0, "ratio": 1.5}')
+        assert result == {"id": 3, "ratio": 1.5}
+        assert isinstance(result["id"], int)
+        assert isinstance(result["ratio"], float)
+
+    def test_nested_float_normalization(self):
+        result = _parse_params('{"host": {"id": 5.0}, "ids": [1.0, 2.0]}')
+        assert result == {"host": {"id": 5}, "ids": [1, 2]}
+
+    def test_invalid_json_raises_value_error(self):
+        with pytest.raises(ValueError, match="must be a valid JSON string"):
+            _parse_params("not json")
+
+    def test_non_object_json_raises_value_error(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _parse_params("[1, 2, 3]")
+
+    def test_none_raises_value_error(self):
+        with pytest.raises(ValueError, match="must be a valid JSON string"):
+            _parse_params(None)
+
+
+class TestNormalizeNumericValues:
+    def test_whole_float_becomes_int(self):
+        assert _normalize_numeric_values(3.0) == 3
+        assert isinstance(_normalize_numeric_values(3.0), int)
+
+    def test_fractional_float_stays_float(self):
+        assert _normalize_numeric_values(3.5) == 3.5
+        assert isinstance(_normalize_numeric_values(3.5), float)
+
+    def test_string_unchanged(self):
+        assert _normalize_numeric_values("hello") == "hello"
+
+    def test_int_unchanged(self):
+        assert _normalize_numeric_values(3) == 3
+
+    def test_nested_dict(self):
+        result = _normalize_numeric_values({"a": 1.0, "b": {"c": 2.0}})
+        assert result == {"a": 1, "b": {"c": 2}}
+
+    def test_list(self):
+        result = _normalize_numeric_values([1.0, 2.5, "x"])
+        assert result == [1, 2.5, "x"]
 
 
 class TestCallForemanApi:


### PR DESCRIPTION
Just trying to push this due to PTO
@shzhou12 I hope this is fine for you 😇🙏🙇‍♂️

This rebases #78 onto `origin/develop` as of now & fixes the ruff check

-- original PR description --
Updated the 'params' argument in the call_foreman_api_get function to expect a string (JSON format) instead of a dictionary. This ensures compatibility with MCP client like Langflow.