### PR TITLE
chore(renovate): restrict fastmcp to patch updates only

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -21,10 +21,16 @@
   "updatePinnedDependencies": false,
   "packageRules": [
     {
-      "description": "Patch-only updates for pyproject.toml dependencies",
+      "description": "Disable major and minor updates for fastmcp only",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["fastmcp"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "Group all pyproject.toml dependencies in one PR",
       "matchManagers": ["pep621"],
       "matchFileNames": ["pyproject.toml"],
-      "matchUpdateTypes": ["patch"],
       "groupName": "pyproject.toml dependencies",
       "groupSlug": "pyproject-deps"
     },


### PR DESCRIPTION
- Disable major and minor updates for fastmcp package
- Keep fastmcp within 2.13.x range (respects >=2.13.0,<2.14.0 constraint)
- Allow normal updates for other pyproject.toml dependencies