### PR TITLE
Enable source image build in Konflux pipelines

### DIFF
--- a/.tekton/foreman-mcp-server-develop-pull-request.yaml
+++ b/.tekton/foreman-mcp-server-develop-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/foreman-mcp-server-develop-push.yaml
+++ b/.tekton/foreman-mcp-server-develop-push.yaml
@@ -25,6 +25,8 @@ spec:
     value: quay.io/foreman/foreman-mcp-server-stage:{{revision}}
   - name: dockerfile
     value: Containerfile
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
## Summary

- Enable `build-source-image: "true"` in the push pipeline
- Enable `build-source-image: "true"` in the pull-request pipeline

The `build-source-image` task was already defined in both pipeline specs (gated by a `when` condition on the param) — this activates it by setting the param to `"true"`.

## Test plan

- [ ] Verify the `build-source-image` task runs in the next PR pipeline triggered
- [ ] Verify the `build-source-image` task runs in the next push pipeline triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)