### PR TITLE
Use custom task-buildah-oci-ta bundle with increased memory limits

### DIFF
--- a/.tekton/foreman-mcp-server-develop-pull-request.yaml
+++ b/.tekton/foreman-mcp-server-develop-pull-request.yaml
@@ -224,7 +224,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.8@sha256:fc685d7c25a3ce588d8bd52306023f57e16402c22507c857a9914f947c99c829
+          value: quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/foreman-mcp-server-develop-push.yaml
+++ b/.tekton/foreman-mcp-server-develop-push.yaml
@@ -221,7 +221,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.8@sha256:fc685d7c25a3ce588d8bd52306023f57e16402c22507c857a9914f947c99c829
+          value: quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- Switches `foreman-mcp-server-develop` push and pull-request pipelines from the upstream `quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.8` to the project-owned `quay.io/foreman/tekton-catalog/task-buildah-oci-ta@sha256:4b16776e9028dc9d51e30cd77e832ce9b4b7a400851ede070f84e780bb20de63`
- The custom bundle increases memory/CPU limits to prevent OOM failures when building large images (see theforeman/theforeman-rel-eng-konflux#20)
- Part of the policy: all OCI image repos must reference the project-owned bundle (tracked in theforeman/theforeman-rel-eng-konflux#40)

## Test plan
- [ ] Verify Konflux pipeline runs successfully with the new bundle reference
- [ ] Confirm no OOM failures in `build` and `sbom-syft-generate` steps

Closes theforeman/theforeman-rel-eng-konflux#40