### PR TITLE
fix: use stage namespace for foreman-mcp-server develop output-image

### DIFF
--- a/.tekton/foreman-mcp-server-develop-pull-request.yaml
+++ b/.tekton/foreman-mcp-server-develop-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/foreman-mcp-server-stage:on-pr-{{revision}}
+    value: quay.io/foreman/stage/foreman-mcp-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/foreman-mcp-server-develop-push.yaml
+++ b/.tekton/foreman-mcp-server-develop-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/foreman/foreman-mcp-server-stage:{{revision}}
+    value: quay.io/foreman/stage/foreman-mcp-server:{{revision}}
   - name: dockerfile
     value: Containerfile
   - name: build-source-image


### PR DESCRIPTION
## Summary

Update `output-image` in Tekton push pipelines to use the new stage namespace convention.

**Before:** `quay.io/foreman/$service-stage:{{revision}}`
**After:** `quay.io/foreman/stage/$service:{{revision}}`

This aligns with theforeman/foremanctl#522, which changes stage image names to use a namespace instead of a name suffix, enabling registry override mirroring between stage and production.